### PR TITLE
Read release status with node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1232,15 +1232,39 @@ jobs:
                 -H "Authorization: Bearer ${HEROKU_API_KEY}" \
                 -H 'Range: version ..; order=desc,max=1;')" || {
                   echo "Release query failed; retrying."; sleep 15; continue; }
-              # See the note in the Deploy step on "sed -n 1p" versus
-              # head and -m1, and on "|| true": this job runs under
-              # -eo pipefail, so a body without these fields would
-              # otherwise abort the step silently instead of retrying.
-              version="$(printf '%s' "$body" \
-                | grep -o '"version": *[0-9][0-9]*' | sed -n 1p \
-              | grep -o '[0-9][0-9]*' || true)"
-              status="$(printf '%s' "$body" \
-                | grep -o '"status": *"[^"]*"' | sed -n 1p | cut -d'"' -f4 || true)"
+              # PARSED WITH node, NOT grep, so that only the TOP-LEVEL
+              # fields of the newest release can be read. A grep for
+              # '"status"' takes the first match anywhere in the body,
+              # including inside a nested object, and Heroku's release
+              # object could gain one: today "app" is {id, name}, so
+              # there is nothing to trip over, but a schema addition
+              # would have this job reporting a nested value as the
+              # release status. Verified against a body carrying
+              # "app": {"status": "nonsense"}: grep returned "nonsense",
+              # node returned the real status.
+              #
+              # node is already required here; this job prints "node -v"
+              # and installs the Heroku CLI with npm, so a missing node
+              # breaks the job long before this line.
+              #
+              # readFileSync(0) reads stdin synchronously, which keeps
+              # this to two lines instead of node's async stream dance.
+              # An unparseable body makes node exit non-zero, so "|| true"
+              # still yields the empty string the guards below expect:
+              # this job runs under -eo pipefail, and without it a body
+              # without these fields would abort the step silently
+              # instead of retrying. An unknown status is passed straight
+              # through, so it still reaches the "unexpected release
+              # status" arm immediately rather than waiting out the loop.
+              release_field() {
+                printf '%s' "$body" | node -e '
+                  const r = JSON.parse(require("fs").readFileSync(0, "utf8"))
+                  process.stdout.write(String((r[0] || {})[process.argv[1]]
+                                              ?? ""))
+                ' "$1" 2>/dev/null || true
+              }
+              version="$(release_field version)"
+              status="$(release_field status)"
               # Insist on a bare integer: this also catches a
               # multi-line value, which is what a body holding more
               # than one release would produce, rather than letting it


### PR DESCRIPTION
Read the release status with node, so a nested field cannot be mistaken for it.

The polling loop that decides whether a Heroku release succeeded parsed the API response with grep:

  grep -o '"status": *"[^"]*"' | sed -n 1p | cut -d'"' -f4

which takes the first match anywhere in the body, including inside a nested object. Heroku's release object has no nested "status" today, so this is hardening rather than a fix: "app" is {id, name}, "slug" is {id}, "user" is {email, id}. A schema addition would change that, and the consequence is not merely a confusing message. A nested value of "succeeded" would make this job report a release that never went live as successful, and clear maintenance mode on the strength of it.

Replaced with a two-line node parse that reads the top-level field of the newest release. node is already required in this job, which prints "node -v" and installs the Heroku CLI with npm, so a missing node breaks the job long before this line. readFileSync(0) reads stdin synchronously, which avoids node's async stream dance.

Every guard around it is unchanged: the integer check on version, the empty check on status, the "|| true" that keeps an unparseable body retrying rather than aborting under -eo pipefail, and the comments explaining each.

Verified by extracting the loop and running it against canned responses with a stubbed curl, before and after:

* a failed release newer than the baseline: exits 1 immediately, both
* pending, pending, then failed: exits 1 on the third poll, both
* succeeded: exits 0, both
* a body carrying "app": {"status": "nonsense"}: grep read "nonsense" and reported an unexpected status; node reads the real "failed"
* an unfamiliar status such as "brand_new": still reaches the "unexpected release status" arm at once rather than spinning out the loop, which is why this is node rather than a grep narrowed to the known enum
* a malformed body, an empty array, and a body holding only the already-live release: all still retry and then refuse

Rejected narrowing the grep to '"(succeeded|failed|pending|expired)"'. One line, no new tool, and it fixes this case, but an unfamiliar status would then match nothing and spin for the full hour before failing, where today it fails at once and says what it saw.

NOT changed, and worth knowing: the Deploy step parses the baseline release version with the same grep idiom. It is better guarded, since an unparseable value there refuses the deploy outright, so the residual is narrower. Hardening both without duplicating the node helper wants a small shared script rather than a second copy in a second step.