### PR TITLE
Fix style offenses found by RuboCop 1.88.2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -115,7 +115,8 @@ end
 # environment", which would otherwise be read as a task using Rails.
 def rake_body_lines(lines)
   closing = /\A\s{#{lines.first[/\A\s*/].size}}end\b/
-  lines.each_with_index.take_while { |text, i| i.zero? || text !~ closing }
+  lines.each_with_index
+       .take_while { |text, i| i.zero? || text !~ closing }
        .map(&:first)
 end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -208,8 +208,7 @@ class ProjectsController < ApplicationController
     id user_id name description homepage_url repo_url
     created_at updated_at lock_version
     tiered_percentage badge_percentage_0 badge_percentage_1 badge_percentage_2
-  ].map { |f| quoted_sql_fieldname(f.to_s) }
-                           .join(',').freeze
+  ].map { |f| quoted_sql_fieldname(f.to_s) }.join(',').freeze
 
   # Memory optimization: Pre-computed field lists for selective Project loading
   # IMPORTANT: These lists control which fields are loaded from the database.

--- a/script/verify_pattern_safety.rb
+++ b/script/verify_pattern_safety.rb
@@ -167,7 +167,7 @@ if File.exist?(ok_file) && File.exist?(not_ok_file)
   if ok_non_matches.any?
     puts
     puts 'Most common missed opportunities (top 10):'
-    frequency = ok_non_matches.each_with_object(Hash.new(0)) { |line, counts| counts[line] += 1 }
+    frequency = ok_non_matches.tally
     frequency.sort_by { |_line, count| -count }
              .first(40).each do |line, count|
       display = line.length > 70 ? "#{line[0, 70]}..." : line

--- a/test/integration/recalc_test.rb
+++ b/test/integration/recalc_test.rb
@@ -383,10 +383,11 @@ class RecalcTest < ActionDispatch::IntegrationTest
     project = projects(:one)
     project.update_column(:unreported_badge_warning, 1)
     project.update_column(:unreported_baseline_badge_warning, 1)
-    sent = Project.send(
-      :send_notifications, Project.where(id: project.id), 1,
-      Project::NOTIFICATION_SERIES[:warning]
-    ) { |_project, _user, _level, _suffix| :sent }
+    sent =
+      Project.send(
+        :send_notifications, Project.where(id: project.id), 1,
+        Project::NOTIFICATION_SERIES[:warning]
+      ) { |_project, _user, _level, _suffix| :sent }
     assert_equal 1, sent
     fresh = Project.find(project.id)
     assert_equal 0, fresh.unreported_badge_warning
@@ -456,10 +457,11 @@ class RecalcTest < ActionDispatch::IntegrationTest
     Project::NOTIFICATION_OUTCOMES.each do |outcome|
       project.update_column(:unreported_badge_warning, 1)
       project.update_column(:warning_send_attempts, 0)
-      sent = Project.send(
-        :send_notifications, Project.where(id: project.id), 1,
-        Project::NOTIFICATION_SERIES[:warning]
-      ) { |_project, _user, _level, _suffix| outcome }
+      sent =
+        Project.send(
+          :send_notifications, Project.where(id: project.id), 1,
+          Project::NOTIFICATION_SERIES[:warning]
+        ) { |_project, _user, _level, _suffix| outcome }
       assert_equal (outcome == :sent ? 1 : 0), sent, "counted #{outcome}"
       assert_equal flag_after[outcome],
                    Project.find(project.id).unreported_badge_warning,
@@ -711,10 +713,11 @@ class RecalcTest < ActionDispatch::IntegrationTest
     end
     log =
       captured_log do
-        sent = Project.send(
-          :send_notifications, Project.where(id: ids).reorder(:id), 1,
-          Project::NOTIFICATION_SERIES[:warning]
-        ) { |_project, _user, _level, _suffix| :sent }
+        sent =
+          Project.send(
+            :send_notifications, Project.where(id: ids).reorder(:id), 1,
+            Project::NOTIFICATION_SERIES[:warning]
+          ) { |_project, _user, _level, _suffix| :sent }
         assert_equal 1, sent
       end
     assert_equal 0, Project.find(ids.first).unreported_badge_warning


### PR DESCRIPTION
RuboCop 1.88.2 flags six correctable offenses that 1.81.7 does not. Fix them by hand instead of autocorrecting, so the results stay under 80 columns:

* Layout/MultilineMethodCallIndentation in Rakefile and projects_controller.rb
* Style/TallyMethod in script/verify_pattern_safety.rb
* Layout/MultilineAssignmentLayout, three times, in recalc_test.rb