### PR TITLE
Bump actions/upload-artifact from 4.6.2 to 7.0.1

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -106,7 +106,7 @@ jobs:
       # fails (if: !cancelled()), so a rejected PR's findings are downloadable.
       - name: Publish Brakeman report (public artifact)
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: brakeman-report
           path: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -66,7 +66,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Update both pinned uses (scorecard.yml and brakeman.yml) of actions/upload-artifact from 4.6.2 to the v7.0.1 commit 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a.

This supersedes dependabot PR #2776, which could not merge. That PR was created when scorecard.yml still carried the stale "# v3.pre.node20" comment on that line, so its context no longer matches main, and it predates brakeman.yml, so it would have left that second use behind at 4.6.2.

Nothing in our usage changes. Across v5 (Node 24 support), v6 (defaults to node24, requiring runner 2.327.1 or later), and v7 (ESM internals plus an optional "archive" input), the inputs we pass (name, path, if-no-files-found, retention-days) are unchanged. We run on GitHub-hosted runners, so the runner version floor is already met.