### PR TITLE
Stop .gitignore from silently hiding our own tracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,17 @@
 /db/*.sqlite3
 /db/*.sqlite3-journal
 
-# Ignore all logfiles and tempfiles.
+# Ignore all logfiles and tempfiles. Ignore the contents of these
+# directories rather than the directories themselves, so the exceptions
+# below can be re-included: git does not descend into an excluded
+# directory, and cannot re-include a path underneath one.
 /log/*
 !/log/.keep
-/tmp
+/tmp/*
+# These two ARE tracked on purpose. They hold a fixed non-secret used by
+# development and test, which tmp/local_secret.notes.md explains.
+!/tmp/local_secret.txt
+!/tmp/local_secret.notes.md
 
 # Don't include precompiled assets
 /public/assets
@@ -43,6 +50,10 @@ requested-paths-*.txt
 
 # Temporary files
 ,*
+# ... except this fixture, which is tracked on purpose. It holds trailing
+# whitespace, so `rake whitespace_check` passing is live proof that the
+# linters really do skip comma-prefixed temporary files.
+!/,whitespace.txt
 *.temp
 *.TEMP
 *.tmp
@@ -66,10 +77,58 @@ requested-paths-*.txt
 tmp/baseline_cache/
 .baseline_sync_metadata.json
 
-# Let's just ignore .files in general
+# Let's just ignore .files in general. The safe default for a dot path is
+# that it holds local state or credentials (editor scratch files, .aws,
+# .ssh, .env.local) which must never be committed, so a dot path we have not
+# vouched for stays out of the repository.
 .*
 
-# ... but .simplecov is real configuration and MUST be tracked. SimpleCov
-# auto-loads it on `require 'simplecov'`, so it is what keeps the test
-# processes and the coverage-merging rake task using identical settings.
+# ... except the dot paths below, which are real project configuration and
+# MUST be tracked. Every tracked dot path needs an entry here. Ignore rules
+# do not apply to files git already tracks, so omitting one leaves the
+# existing file working while a NEW or deleted-then-restored file becomes
+# silently invisible: absent from `git status` and refused by `git add`. It
+# then looks committed while never leaving the local machine.
+#
+# Directories are re-included as directories rather than by a pattern for
+# the files inside them, because git does not descend into an excluded
+# directory and so would never consult such a pattern.
+#
+# To confirm the list is complete, this must print nothing:
+#   git ls-files | git check-ignore --no-index --stdin
+# You do not have to remember to run it. "rake gitignore_check" runs
+# exactly that, as one of the static checks in "rake default", and it
+# covers the exceptions to the /tmp and ",*" rules above as well.
+
+# Rails marks otherwise-empty tracked directories with a placeholder.
+!.keep
+!.gitkeep
+
+# CI and repository configuration.
+!/.github/
+!/.circleci/
+
+# Served to the public by the site itself, e.g. /.well-known/security.txt.
+!/public/.well-known/
+
+# translation.io project state.
+!/config/locales/.translation_io
+
+# Tool configuration, one file each. SimpleCov auto-loads .simplecov on
+# `require 'simplecov'`, so it is what keeps the test processes and the
+# coverage-merging rake task using identical settings.
+!/.bundler-audit.yml
+!/.codespellignore
+!/.codespellrc
+!/.env
+!/.eslintignore
+!/.eslintrc
+!/.fasterer.yml
+!/.gitignore
+!/.mdlrc
+!/.pryrc
+!/.rubocop.yml
+!/.ruby-version
 !/.simplecov
+!/.slugignore
+!/.tool-versions

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -19,6 +19,7 @@
 
 require 'English'
 require 'json'
+require 'open3'
 
 # ---------------------------------------------------------------------
 # EVERY TASK WITH A BODY MUST SAY WHETHER IT NEEDS RAILS.
@@ -88,6 +89,7 @@ STATIC_CHECKS = %w[
   license_okay
   yaml_syntax_check
   circleci_config_check
+  gitignore_check
   codeql_version_check
   ruby_version_matches_lock
   html_from_markdown
@@ -518,6 +520,56 @@ task circleci_config_check: :no_rails do
     offenders.each do |line_number, text|
       puts "  #{path}:#{line_number}: #{text}"
     end
+    exit 1
+  end
+end
+
+# .gitignore ignores dot paths by default (".*"), which is the right
+# default for credentials and editor state, and then re-includes the dot
+# paths that are real configuration. That list has to stay complete, and
+# nothing about an incomplete one is visible day to day: ignore rules do
+# not apply to files git already tracks, so a tracked file whose entry is
+# missing keeps working. The bill comes due later, when the file is
+# deleted and restored, or when a new file lands beside it: git status
+# never mentions it and git add refuses it, so it looks committed while
+# never leaving the machine it was written on. That is the failure this
+# catches, and it applies to any ignore rule, not just ".*" (/tmp and
+# ",*" each hide a tracked file too, and each has its own exception).
+#
+# Being tracked and being ignored is the contradiction, so ask git both
+# questions and intersect the answers.
+desc 'Check no tracked file is covered by an ignore rule'
+task gitignore_check: :no_rails do
+  puts 'Checking that no tracked file is ignored...'
+  tracked = `git ls-files -z`
+  unless $CHILD_STATUS.success?
+    raise StandardError, 'git ls-files failed; not a git work tree?'
+  end
+  raise StandardError, 'git ls-files reported no files' if tracked.empty?
+
+  # capture2 pumps stdin and stdout on separate threads. Feeding this
+  # much input to a pipe we also read from would otherwise risk a
+  # deadlock, on precisely the broken .gitignore that makes the output
+  # large. check-ignore exits 0 when something matched, 1 when nothing
+  # did, and 128 on a real error, so 1 is the answer we want.
+  output, status = Open3.capture2(
+    'git', 'check-ignore', '--no-index', '--stdin', '-z',
+    stdin_data: tracked
+  )
+  if status.exitstatus > 1
+    raise StandardError, "git check-ignore failed (#{status.exitstatus})"
+  end
+
+  offenders = output.split("\0").reject(&:empty?)
+  if offenders.empty?
+    puts 'No tracked file is ignored.'
+  else
+    puts 'ERROR: these files are tracked, yet .gitignore ignores them.'
+    puts 'Deleting and restoring one, or adding a file beside it, will'
+    puts 'fail silently. Add an exception ("!" line) for each, after'
+    puts 'the rule that hides it. To see which rule that is, run:'
+    puts '  git ls-files | git check-ignore --no-index --stdin -v'
+    offenders.each { |file| puts "  #{file}" }
     exit 1
   end
 end


### PR DESCRIPTION
.gitignore ignores dot paths in general (".*"), which is the right default: an unvouched-for dot path is credentials or editor state and must stay out. But only .simplecov was ever re-included, so every other tracked dot path was ignored too, .github and .circleci among them.

Nothing showed a symptom, because ignore rules do not apply to files git already tracks. The cost arrives later. A NEW file under .github (a workflow, CODEOWNERS, an issue template) was absent from "git status" and refused by "git add", so it looked committed while never leaving the machine it was written on, and the same trap waited for any of these files that was ever deleted and restored.

So keep the default and re-include what is real: .keep and .gitkeep placeholders anywhere, the .github and .circleci directories, public/.well-known (which the site serves, e.g. security.txt), config/locales/.translation_io, and the fifteen top-level tool configuration files from .bundler-audit.yml through .tool-versions.

Three tracked files were hidden the same way by non-dot rules, so fix them too. tmp/local_secret.txt and tmp/local_secret.notes.md hold a fixed non-secret that development and test need. ",whitespace.txt" holds trailing whitespace, so "rake whitespace_check" passing is what proves the linters really do skip comma-prefixed temporary files. Ignoring the CONTENTS of tmp (/tmp/*) rather than the directory itself is what makes those exceptions expressible, mirroring the existing /log/* and !/log/.keep pair, since git cannot re-include a path underneath an excluded directory. Directories are re-included as directories for the same reason.

An allowlist is only correct while it stays complete, and this whole failure mode is silent, so add "rake gitignore_check" to the static checks rather than trusting a comment. Being tracked and being ignored is the contradiction, so it asks git both questions and intersects them: "git ls-files" piped into "git check-ignore --no-index --stdin" must come back empty. It covers every ignore rule, not just ".*", so the /tmp and ",*" exceptions are held in place too. .gitignore now names the task at the spot that documents the invariant.

The check is static: the same tree always gives the same answer, so it runs in the parallel CI job, not on every deploy. It uses Open3.capture2 rather than a pipe it both writes and reads, because feeding a thousand paths into such a pipe can deadlock, and would do so exactly when .gitignore is broken enough to make the output large. check-ignore exits 1 when nothing matched, which is the passing case, and 128 on a real error, so anything above 1 raises. An empty ls-files result raises as well, so running outside a work tree cannot look clean.

Verified in both directions. The check is green on this tree, and putting ".mdlrc" back into .gitignore makes it fail and name that file. New files under .github, .circleci, and public/.well-known now appear in "git status", while .env.local, .DS_Store, .aws/credentials, .ssh/id_rsa, .vscode/settings.json, dotfiles nested inside .github, ",scratch.rb", tmp/cache/x, and log/dev.log all stay ignored.


Assisted-by: Claude:claude-opus-5