### PR TITLE
Fix arm64 Linux system test setup and 2 test bugs

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -79,12 +79,58 @@ tools, e.g., at the command line:
 * <kbd>emerge install git</kbd> (Gentoo)
 * <kbd>brew install git</kbd> (MacOS)
 
-Also, install Chrome.
+Also, install Chrome (or Chromium; see below).
 It's not needed to *run* the software, but it's used for various headless tests
 so you need it to run some automated tests.
-The easy way to do this is to download it from
-<https://www.google.com/chrome>.
-Chromedriver is now managed by selenium.
+
+On x86_64 Linux, and on MacOS on either Intel or Apple Silicon (Selenium's
+own downloader ships as a universal binary there), the easy way is to
+download Chrome from <https://www.google.com/chrome>. Chromedriver is
+managed by Selenium, which downloads a matching driver automatically.
+On x86_64 Ubuntu this isn't required, but the Chromium snap described
+below (with the same `SE_CHROMEDRIVER` setup) works there too, if you'd
+rather use Chromium than Chrome.
+
+**On arm64 Linux, don't use Google's Chrome build.** Selenium's own
+downloader (Selenium Manager) ships as an x86_64-only binary on Linux and
+can't run at all on arm64, and Google doesn't reliably publish arm64
+Linux chromedriver builds outside its Dev/Canary channels.
+If you're using Ubuntu, install Canonical's Chromium snap instead, which
+ships a matched browser and chromedriver pair for arm64:
+
+~~~~sh
+sudo snap install chromium
+~~~~
+
+`test/application_system_test_case.rb` auto-detects this: on arm64 Linux,
+if `SE_CHROMEDRIVER` isn't already set, it points Selenium at
+`/snap/bin/chromium.chromedriver` itself, so it never tries (and fails)
+to resolve one another way. There's nothing to configure once the snap
+above is installed, and system tests fail immediately with a clear
+message if it isn't. Set `SE_CHROMEDRIVER` yourself only if you installed
+the snap somewhere nonstandard, or want a different chromedriver; add it
+to your shell init file so it persists: `~/.bash_aliases` if your
+`~/.bashrc` sources it (Ubuntu's default one does), otherwise `~/.bashrc`
+itself:
+
+~~~~sh
+export SE_CHROMEDRIVER=/snap/bin/chromium.chromedriver
+~~~~
+
+`SE_CHROMEDRIVER` is read directly by the `selenium-webdriver` gem, and
+takes precedence over the auto-detection above.
+
+**Don't also set a `CHROME_BINARY` pointing at `/snap/bin/chromium`.** That
+path is a symlink to `/usr/bin/snap`, which re-enters snap's privileged
+launch machinery; a strictly-confined process (chromedriver, in this case)
+isn't allowed to invoke that, and AppArmor denies it, so the browser fails
+to launch. Leave the browser binary unset and chromedriver finds its own
+bundled Chromium directly (e.g.
+`/snap/chromium/3506/usr/lib/chromium-browser/chrome`), inside its own
+confinement, without going through the wrapper.
+`test/application_system_test_case.rb` does support a `CHROME_BINARY`
+override for other cases (e.g. a non-snap Chrome install in a nonstandard
+location); just don't point it at a confined snap's wrapper.
 
 ## Forking the repo
 

--- a/install-badge-dev-env
+++ b/install-badge-dev-env
@@ -439,6 +439,50 @@ if ! git config user.name > /dev/null ; then
 fi
 
 echo
+echo 'STAGE 8: Check for a browser to run headless system tests with'
+
+# This only applies to arm64 Linux. On x86_64 Linux (and on macOS,
+# arm64 included: Selenium Manager ships as a universal binary there),
+# Google Chrome plus Selenium Manager just works, so don't suggest
+# Chromium there - it would be a pointless extra install, and the
+# snap's own confinement quirks (see docs/INSTALL.md) aren't worth
+# taking on where they're not needed.
+arch="$(uname -m)"
+if [ -f /etc/os-release ] && grep -q '^NAME="Ubuntu"' /etc/os-release &&
+   { [ "$arch" = 'aarch64' ] || [ "$arch" = 'arm64' ]; } &&
+   ! is_command chromium && ! is_command chromium-browser &&
+   ! [ -e /snap/bin/chromium ] ; then
+  echo 'Ubuntu on arm64 detected, and no Chromium found.'
+  echo 'System tests need a browser, and on arm64 Linux, Google Chrome'
+  echo 'itself runs fine but Selenium can'"'"'t drive it: Selenium Manager'
+  echo 'is x86_64-only and never runs at all here, and Google only'
+  echo 'publishes arm64 chromedriver builds sporadically outside Stable.'
+  echo 'Suggest installing Canonical'"'"'s Chromium snap instead, which ships'
+  echo 'a matched browser + chromedriver pair for arm64:'
+  echo '  sudo snap install chromium'
+  echo 'test/application_system_test_case.rb auto-detects it there, so'
+  echo 'nothing else to configure (and do NOT set CHROME_BINARY to'
+  echo '/snap/bin/chromium; see docs/INSTALL.md for why). Only if you'
+  echo 'installed the snap somewhere nonstandard do you need to set'
+  echo '  export SE_CHROMEDRIVER=/path/to/chromedriver'
+  # Prefer ~/.bash_aliases when it's actually sourced (Ubuntu's default
+  # .bashrc does this) - it's the tidier place for one-off exports like
+  # this, kept separate from shell_init's own PATH/rbenv setup above.
+  # Falling back to shell_init avoids suggesting a file nothing reads.
+  init_target="$shell_init"
+  if [ -f "$HOME/.bash_aliases" ] && [ -n "$shell_init" ] &&
+     grep -q 'bash_aliases' "$shell_init" 2>/dev/null ; then
+    init_target="$HOME/.bash_aliases"
+  fi
+  if [ -n "$init_target" ] ; then
+    echo "yourself, added to $init_target so it persists across sessions."
+  else
+    echo 'yourself, added to your shell init file so it persists across'
+    echo 'sessions.'
+  fi
+fi
+
+echo
 echo 'FINAL STAGE: Test to see if it is working'
 
 # On initial setup the test in feed_test.rb will fail with an

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -127,9 +127,22 @@ DYNAMIC_CHECKS = %w[
 # Everything, which is what a developer wants from one word, and what
 # runs on a machine with no CI to split the work across. Defined from
 # the two halves so it cannot drift from what CI actually runs.
-task(:default).clear.enhance(
-  %w[notice whitespace_check] + %w[static_checks dynamic_checks]
-)
+DEFAULT_TASKS = %w[notice whitespace_check static_checks dynamic_checks].freeze
+task(:default).clear.enhance(DEFAULT_TASKS)
+
+# Rails' own railties/lib/rails/test_unit/testing.rake, loaded by the
+# Rakefile's later "Rails.application.load_tasks", does "task default:
+# :test". That "task" call does not know :default is already ours: Rake
+# merges prerequisites for a task defined twice rather than replacing
+# them, so it silently appends :test after DEFAULT_TASKS instead of
+# overriding it. The symptom was "rake" quietly running the regular test
+# suite a second time (via Rails' in-process runner, so with none of
+# test:optimized's output) after everything else had already passed.
+# Reasserting our own list here, once Rails has had its say, is what
+# undoes that append. See the Rakefile for after_rails_tasks.
+after_rails_tasks do
+  task(:default).clear.enhance(DEFAULT_TASKS)
+end
 
 desc 'Checks settled by the commit; CI runs these in a parallel job'
 task(:static_checks).clear.enhance(PREFLIGHT + STATIC_CHECKS)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -88,6 +88,35 @@ SELENIUM_OPTIONS =
     {}
   end
 
+# Selenium Manager (selenium-webdriver's own chromedriver resolver) ships
+# as an x86_64-only binary and cannot run at all on arm64 Linux. Left
+# alone it fails deep inside Selenium with "Syntax error: '(' unexpected"
+# instead of an explanation, ten seconds into the first test, which reads
+# as an unrelated failure. Rather than rely on a developer having set
+# SE_CHROMEDRIVER themselves (easy to forget, and it fails exactly this
+# way if forgotten), auto-detect the one setup docs/INSTALL.md
+# recommends - the Chromium snap - and fail fast with a clear message if
+# that is not present either. Skipped for SELENIUM_REMOTE_URL, which
+# never invokes Selenium Manager locally in the first place (see above).
+if SELENIUM_REMOTE_URL.nil? && ENV['SE_CHROMEDRIVER'].nil? &&
+   RUBY_PLATFORM == 'aarch64-linux'
+  snap_chromedriver = '/snap/bin/chromium.chromedriver'
+  unless File.executable?(snap_chromedriver)
+    raise StandardError, <<~MESSAGE
+      arm64 Linux detected, but no chromedriver is configured, and the
+      Chromium snap (the setup docs/INSTALL.md recommends) isn't
+      installed either.
+
+      Selenium Manager cannot resolve one itself here - it is x86_64-only
+      - so system tests cannot run without one. See docs/INSTALL.md for
+      how to install the Chromium snap, or set SE_CHROMEDRIVER yourself
+      if you already have a chromedriver elsewhere.
+    MESSAGE
+  end
+
+  ENV['SE_CHROMEDRIVER'] = snap_chromedriver
+end
+
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # DRIVER and SELENIUM_REMOTE_URL are independent, and all four
   # combinations work. DRIVER picks the browser: unset means
@@ -104,5 +133,12 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     # renderer process crashes, killing the browser session and cascading into
     # spurious errors in later tests. This flag is the standard fix.
     option.add_argument('disable-dev-shm-usage')
+    # On arm64 Linux, Selenium Manager's bundled resolver binary is
+    # x86_64-only and cannot run at all, and Google publishes no reliable
+    # arm64 chromedriver on the Stable channel. CHROME_BINARY lets a
+    # matched browser (e.g. the Chromium snap) be pointed at directly,
+    # skipping that resolution. See docs/INSTALL.md.
+    chrome_binary = ENV.fetch('CHROME_BINARY', nil)
+    option.binary = chrome_binary if chrome_binary
   end
 end

--- a/test/lib/heroku_ruby_availability_test.rb
+++ b/test/lib/heroku_ruby_availability_test.rb
@@ -115,13 +115,14 @@ class HerokuRubyAvailabilityTest < ActiveSupport::TestCase
         [%w[3.5.3], '3.5', -1, '3.5.3']
     }.each do |intent, (published, searched, after, expected)|
       publish(*published)
-      assert_equal(
-        expected,
-        HerokuRubyAvailability.highest_patch(
-          line: searched, after: after, stack: STACK
-        ),
-        "should find #{intent}"
+      actual = HerokuRubyAvailability.highest_patch(
+        line: searched, after: after, stack: STACK
       )
+      if expected.nil?
+        assert_nil actual, "should find #{intent}"
+      else
+        assert_equal expected, actual, "should find #{intent}"
+      end
     end
 
     # A bucket answering 200 to everything must not become a crawl.

--- a/test/system/github_project_test.rb
+++ b/test/system/github_project_test.rb
@@ -25,6 +25,17 @@ class GithubProjectTest < ApplicationSystemTestCase
       num = ActionMailer::Base.deliveries.size
       click_link 'Log in with GitHub'
 
+      # The mocked OmniAuth flow redirects through /auth/github and its
+      # callback with no real network latency between hops, so without
+      # this Capybara can poll mid-redirect and hand Selenium a node
+      # reference from a document that's already been replaced -
+      # ChromeDriver then raises "unknown error: unhandled inspector
+      # error: Node with given id does not belong to the document"
+      # instead of the missing-content error Capybara would normally
+      # retry on. Settling on document.readyState first (which reflects
+      # whatever page is current rather than caching a node) avoids that.
+      wait_for_page_load
+
       # When re-recording cassetes you must use DRIVER=chrome
       # Github has an anti bot mechanism that requires real mouse movement
       # to authorize an application.


### PR DESCRIPTION
arm64 Linux can't run Selenium Manager (x86_64-only) and Google doesn't reliably publish arm64 chromedriver on Stable, so system tests couldn't run there at all. Auto-detect the Chromium snap's chromedriver (the one setup docs/INSTALL.md now recommends for arm64) when SE_CHROMEDRIVER isn't already set, and fail fast with a clear message if neither is available. install-badge-dev-env now suggests installing the snap on Ubuntu/arm64 when no Chromium is found, and documents where to persist SE_CHROMEDRIVER if you need it yourself. Fixed the assert_equal-with-nil deprecation warning in heroku_ruby_availability_test.rb while in there.

Also fixes two bugs surfaced while shaking out this setup:

- Bare "rake" ran the regular test suite twice. Rails' own railties/lib/rails/test_unit/testing.rake does "task default: :test", and since Rake merges rather than replaces prerequisites for a task defined twice, it silently appended :test onto our own task(:default) list. Reassert our own list in an after_rails_tasks block, once Rails has had its say, the same pattern already used for test:run and translation:sync.

- github_project_test.rb flaked with a Selenium "Node with given id does not belong to the document" error. The mocked OmniAuth flow redirects through /auth/github and its callback with no real network latency between hops, so has_content? could poll mid-redirect and get handed a node from an already-replaced document. wait_for_page_load settles on document.readyState instead of holding a node reference, so it isn't racy the same way.

Assisted-by: Claude:claude-sonnet-5