### PR TITLE
Split rubocop-family gems into their own dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -159,6 +159,13 @@ updates:
       gems-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          # Same reasoning as gems-minor below: we're sensitive to any
+          # rubocop-family change, patch included, so these always arrive
+          # on their own.
+          - "rubocop"
+          - "rubocop-rails"
+          - "rubocop-performance"
         update-types:
           - "patch"
       # MINOR BUMPS ARE BATCHED ONLY WHERE SEMVER IS TRUSTWORTHY. The
@@ -186,8 +193,11 @@ updates:
         exclude-patterns:
           # Exact-pinned in the Gemfile
           - "mdl"
+          # Any update to rubocop tends to break builds since we require
+          # its rules to pass, so even a minor update isn't minor for us
           - "rubocop"
           - "rubocop-rails"
+          - "rubocop-performance"
           - "ruby-graphviz"
           - "sprockets-rails"
           - "translation"


### PR DESCRIPTION
Any rubocop, rubocop-rails, or rubocop-performance update tends to break the build: new cops fail our all-cops-must-pass CI check, so even a minor bump isn't "minor" for us. rubocop and rubocop-rails were already excluded from the gems-minor batch as exact-pinned gems, but rubocop-performance (capped with "~>", not exact-pinned) was not, so it kept batching with unrelated gems in gems-minor. PR #2968 is the result: rubocop-performance 1.26.1 -> 1.27.0 bundled with sprockets and tilt.

Exclude all three from both gems-minor and gems-patch so each always arrives as its own pull request, separate from every other gem and from each other.

Assisted-by: Claude:claude-sonnet-5