### PR TITLE
Fix pull_production's Rails marker and audit

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -131,6 +131,24 @@ def rake_rails_regexp
                /\bI18n\b/, *models.map { |m| /\b#{m}\b/ })
 end
 
+# Task names a body invokes by string, e.g. "Rake::Task['db:migrate']".
+# These bypass rake_needs_rails?'s walk of *declared* prerequisites: a
+# task can claim ':no_rails' and still reach into Rails at runtime this
+# way, and nothing catches it until the body actually runs and the name
+# does not exist yet, "don't know how to build task 'db:migrate'".
+def rake_body_task_refs(body)
+  body.scan(/Rake::Task\[\s*(['"])(.*?)\1\s*\]/).map(&:last)
+end
+
+# Does this task's body evidently need Rails: a direct reference (Rails,
+# ActiveRecord, a model, ...) or an invocation of a task that does, such
+# as "Rake::Task['db:migrate']" reaching past the declared prerequisites
+# that rake_needs_rails? would otherwise walk.
+def rake_body_needs_rails?(task, rails_re)
+  body = rake_task_body(task)
+  body.match?(rails_re) || rake_body_task_refs(body).any? { |r| rake_needs_rails?(r) }
+end
+
 # [tasks that answered nothing, tasks whose answer contradicts the body]
 def rake_marker_problems(names)
   rails_re = rake_rails_regexp
@@ -141,10 +159,13 @@ def rake_marker_problems(names)
     prereqs = task.prerequisites.map(&:to_s)
     next if prereqs.include?('environment')
 
-    if !prereqs.include?('no_rails')
+    if prereqs.include?('no_rails')
+      # A sibling prerequisite (like "test:ensure_assets") can already
+      # pull Rails in even though this task's OWN body does not need
+      # it; rake_needs_rails? walks that whole tree, so defer to it.
+      wrong << name if rake_body_needs_rails?(task, rails_re) && !rake_needs_rails?(name)
+    else
       unanswered << name
-    elsif rake_task_body(task).match?(rails_re)
-      wrong << name
     end
   end
 end
@@ -154,13 +175,13 @@ def audit_rake_markers!(names)
   return if unanswered.empty? && wrong.empty?
 
   message = ['Every task with a body must say whether it needs Rails.']
-  unless unanswered.empty?
+  if unanswered.any?
     message << "Says neither, add ': :environment' or ': :no_rails' to: " \
                "#{unanswered.sort.join(', ')}"
   end
-  unless wrong.empty?
-    message << "Claims ':no_rails' but the body uses Rails: " \
-               "#{wrong.sort.join(', ')}"
+  if wrong.any?
+    message << "Claims ':no_rails' but the body needs Rails, directly or " \
+               "by invoking a task that does: #{wrong.sort.join(', ')}"
   end
   raise message.join("\n  ")
 end

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1123,7 +1123,7 @@ task drop_database: :no_rails do
 end
 
 desc 'Copy database from production into development (requires access privs)'
-task pull_production: :no_rails do
+task pull_production: :environment do
   puts 'Getting production database'
   Rake::Task['drop_database'].reenable
   Rake::Task['drop_database'].invoke


### PR DESCRIPTION
pull_production was marked ':no_rails', but its body always finishes by invoking Rake::Task['db:migrate'], a Rails-provided task. Since that call isn't a declared Rake prerequisite, the Rakefile's static "does this need Rails?" check never saw it, so Rails never booted and db:migrate didn't exist yet: "don't know how to build task 'db:migrate'". Mark it ':environment' instead, since it does need Rails.

Also extend the Rakefile's marker audit to catch this whole bug class: a ':no_rails' task whose body invokes another task (by name, via Rake::Task[...]) that needs Rails, not just a task whose body references Rails/ActiveRecord/a model directly. The check still defers to rake_needs_rails? for the enclosing task itself, so a task like test:optimized that gets Rails via a sibling prerequisite isn't flagged.

Assisted-by: Claude:claude-sonnet-5