### PR TITLE
Make automated translation tool configurable, not hardcoded to Copilot

### DIFF
--- a/config/machine_translations/fr.yml
+++ b/config/machine_translations/fr.yml
@@ -315,6 +315,9 @@ fr:
   account_activations:
     delay:
       many: En tant que mesure anti-spam, vous devez attendre %{count} heures après l'activation avant de pouvoir vous connecter.
+    link_invalid_or_used: 'L''activation a échoué. Si votre compte est déjà activé, veuillez vous connecter.
+
+      '
   detectives:
     github:
       repo_public: Dépôt sur GitHub, qui fournit des dépôts git publics avec des URLs.
@@ -372,3 +375,6 @@ fr:
       obsolete: Obsolète
   criteria_overall:
     obsolete: "{Obsolète}"
+  pagination:
+    first: Première
+    last: Dernière

--- a/config/machine_translations/src_en_fr.yml
+++ b/config/machine_translations/src_en_fr.yml
@@ -319,6 +319,9 @@ en:
       many: 'As an anti-spam measure, you must wait %{count} hours after activation before you can log in.
 
         '
+    link_invalid_or_used: 'Activation failed. If your account is already activated, please log in.
+
+      '
   detectives:
     github:
       repo_public: Repository on GitHub, which provides public git repositories with URLs.
@@ -376,3 +379,6 @@ en:
       obsolete: Obsolete
   criteria_overall:
     obsolete: "{Obsolete}"
+  pagination:
+    first: First
+    last: Last

--- a/docs/baseline_update.md
+++ b/docs/baseline_update.md
@@ -357,9 +357,10 @@ rake translation:all
 
 This iterates over all locales that have untranslated or stale segments
 (i.e., where the English source has changed since the machine translation
-was generated) and translates them using GitHub Copilot. It runs until all
-locales are up to date. Human translations always take precedence over
-machine translations.
+was generated) and translates them using an AI CLI tool (see
+[machine-translations.md](./machine-translations.md) for which tool and
+how to change it). It runs until all locales are up to date. Human
+translations always take precedence over machine translations.
 
 You can check translation status before and after with:
 

--- a/docs/machine-translations.md
+++ b/docs/machine-translations.md
@@ -131,7 +131,7 @@ for quality through:
 
 Translation APIs charge per character or request. With thousands of
 translation keys and frequent updates, costs would accumulate quickly.
-Our approach uses AI (like GitHub Copilot) in controlled batches,
+Our approach uses an AI CLI tool in controlled batches,
 keeping costs predictable and manageable.
 
 ### 5. Source Tracking
@@ -166,8 +166,8 @@ When machine-translating text to a target language (e.g., French):
    human translations that already use that phrase.
 
 4. **Create example files**: Generate two YAML files:
-   - `copilot_examples_en_*.yml`: English text with the identified terms
-   - `copilot_examples_fr_*.yml`: How humans translated those terms
+   - `examples_en_fr_*.yml`: English text with the identified terms
+   - `examples_fr_*.yml`: How humans translated those terms
 
 5. **Generate translations**: Provide the AI with:
    - The text to translate
@@ -339,9 +339,9 @@ rake translation:export
 5. Creates example files showing how humans translated similar content
 6. Generates:
    - `tmp/translate_to_LOCALE_TIMESTAMP.yml` (keys to translate)
-   - `copilot_examples_en_TIMESTAMP.yml` (English examples)
-   - `copilot_examples_LOCALE_TIMESTAMP.yml` (translated examples)
-   - `tmp/translate_instructions_LOCALE_TIMESTAMP.txt` (detailed instructions)
+   - `tmp/examples_en_LOCALE_TIMESTAMP.yml` (English examples)
+   - `tmp/examples_LOCALE_TIMESTAMP.yml` (translated examples)
+   - `tmp/TRANSLATION_INSTRUCTIONS_LOCALE.txt` (detailed instructions)
 
 The output files contain everything needed to translate the keys, whether
 using an AI, a human translator, or any translation tool.
@@ -413,13 +413,25 @@ Lists keys needing translation for a specific locale.
 Shows the first 20 untranslated keys and a count of how many total
 untranslated keys exist. Useful for understanding translation workload.
 
-### Automated Translation via GitHub Copilot
+### Automated Translation via an AI CLI Tool
 
 ```bash
-rake translation:copilot[LOCALE,COUNT]
+rake translation:ai[LOCALE,COUNT]
 ```
 
-Fully automated translation using GitHub Copilot CLI.
+Fully automated translation using an AI CLI tool.
+
+**Which tool runs**: Set by the `BADGEAPP_TRANSLATION_AI_CLI` environment
+variable (default: `claude`, invoking the Claude Code CLI). We made this
+configurable rather than hardcoding a specific vendor's tool because
+we've already had to switch once, when GitHub Copilot CLI access went
+away. `BADGEAPP_TRANSLATION_AI_MODEL` selects the model (default:
+`sonnet`), and `BADGEAPP_TRANSLATION_AI_ARGS` overrides the full argument
+list the tool is invoked with (default: read/write-only tool access,
+confined to the `tmp/` working directory, with file edits auto-accepted
+and no on-disk session saved) if a replacement tool needs different flags
+to get the same restrictions. See `AI_CLI`, `AI_CLI_MODEL`, and
+`AI_CLI_ARGS` in `lib/tasks/machine_translation_helpers.rb`.
 
 **Parameters:**
 
@@ -430,10 +442,10 @@ Fully automated translation using GitHub Copilot CLI.
 
 ```bash
 # Translate 20 keys to French
-rake translation:copilot[fr,20]
+rake translation:ai[fr,20]
 
 # Auto-select locale and translate 20 keys
-rake translation:copilot
+rake translation:ai
 ```
 
 **What it does:**
@@ -441,14 +453,14 @@ rake translation:copilot
 This is a complete end-to-end automation:
 
 1. Runs `translation:export` to create files
-2. Invokes GitHub Copilot CLI with detailed translation instructions
-3. Copilot translates the keys using the provided examples
-4. Copilot reviews its own translations for quality
+2. Invokes the configured AI CLI tool with detailed translation instructions
+3. The AI tool translates the keys using the provided examples
+4. The AI tool reviews its own translations for quality
 5. Validates the resulting YAML
 6. Runs `translation:import` to add the translations
 
-**Security**: The Copilot process runs in a restricted environment
-with read/write access only to a `tmp/` directory. It cannot modify
+**Security**: The AI tool runs in a restricted environment with
+read/write access only to a `tmp/` directory. It cannot modify
 source code or configuration directly.
 
 This task is safe to run repeatedly.
@@ -457,7 +469,7 @@ translations without overwhelming the AI or incurring high costs.
 
 ## Translation Workflow (Manual)
 
-For human review or non-Copilot translation:
+For human review or manual (non-`translation:ai`) translation:
 
 1. **Export** untranslated keys:
 
@@ -525,7 +537,7 @@ Machine translations go through multiple validation layers:
 
 ### 1. AI Self-Review
 
-When using Copilot, we use a two-step process:
+When using `translation:ai`, we use a two-step process:
 
 1. Initial translation
 2. AI reviews its own translation, comparing to source and examples,

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -99,7 +99,7 @@ automatically invalidated.
 
 ### Example-Based Translation
 
-When automated translation is performed using Copilot, the system
+When automated translation is performed using an AI CLI tool, the system
 automatically provides example translations to help maintain consistent
 terminology across the application.
 
@@ -117,8 +117,8 @@ terminology across the application.
    (limited to 15 examples to avoid overwhelming the AI).
 
 3. **Example Files**: Creates two example YAML files:
-   - `copilot_examples_en_*.yml` - English source with technical terms
-   - `copilot_examples_{locale}_*.yml` - How those terms were previously translated
+   - `examples_en_{locale}_*.yml` - English source with technical terms
+   - `examples_{locale}_*.yml` - How those terms were previously translated
 
 4. **Prompt Integration**: The translation prompt instructs the AI to review
    these examples and use the same translations for the same terms.
@@ -209,7 +209,7 @@ Lists keys that need translation for a specific locale.
    ```
 
 2. **Translate** the exported YAML file using any tool:
-   - GitHub Copilot
+   - An AI CLI tool (e.g., `rake translation:ai`)
    - ChatGPT or other LLMs
    - Human translator
    - Any translation service
@@ -249,9 +249,12 @@ Machine translations are processed in this priority order:
 
 ## Automatically translating
 
-Run `translation:copilot` to automatically call GitHub pilot to
-perform translations of what needs translating and add them.
-When run, copilot only has read/write access to a `tmp` directory.
+Run `translation:ai` to automatically call an AI CLI tool to perform
+translations of what needs translating and add them. When run, the AI tool
+only has read/write access to a `tmp` directory. The specific tool invoked
+is configurable (see [machine-translations.md](./machine-translations.md))
+since we've already had to switch tools once, when GitHub Copilot CLI
+access went away; it currently defaults to the Claude Code CLI.
 
 Run `translation:all` to repeatedly call this, with breaks in between.
 The goal is to slowly fill in

--- a/lib/tasks/machine_translation_helpers.rb
+++ b/lib/tasks/machine_translation_helpers.rb
@@ -4,6 +4,7 @@
 # OpenSSF Best Practices badge contributors
 # SPDX-License-Identifier: MIT
 
+require 'shellwords'
 require_relative 'translation_instructions_template'
 
 # Helper methods for machine translation rake tasks.
@@ -32,8 +33,25 @@ module MachineTranslationHelpers
     'es' => 'Spanish', 'ru' => 'Russian', 'sw' => 'Swahili'
   }.freeze
 
-  # Default batch size for Copilot translations (balance speed vs accuracy)
-  COPILOT_BATCH_SIZE = 20
+  # Default batch size for AI-assisted translations (balance speed vs accuracy)
+  AI_BATCH_SIZE = 20
+
+  # Which AI CLI tool to run for automated translation, and how to invoke
+  # it. All configurable via environment variables so we can switch tools
+  # without a code change; we've already had to do this once, when GitHub
+  # Copilot CLI access went away. Defaults target the Claude Code CLI,
+  # restricted to reading/writing files, confined to the tmp/ working
+  # directory, with edits auto-accepted (no human is present to approve
+  # them) and no on-disk session saved. A different CLI will need different
+  # flags for the same restrictions; override AI_CLI_ARGS entirely in that
+  # case rather than trying to keep one flag syntax working for every tool.
+  AI_CLI = ENV.fetch('BADGEAPP_TRANSLATION_AI_CLI', 'claude')
+  AI_CLI_MODEL = ENV.fetch('BADGEAPP_TRANSLATION_AI_MODEL', 'sonnet')
+  AI_CLI_ARGS = ENV.fetch(
+    'BADGEAPP_TRANSLATION_AI_ARGS',
+    '--tools Read,Write --permission-mode acceptEdits --restricted ' \
+    "--model #{AI_CLI_MODEL} --no-session-persistence"
+  )
 
   # Translation example counts for consistency and quality
   MIN_TRANSLATION_EXAMPLES = 20 # Minimum examples to provide (if available)
@@ -338,15 +356,15 @@ module MachineTranslationHelpers
       end
     end
 
-    # Copilot integration methods
+    # AI CLI integration methods
 
-    def copilot_lock_path
-      Rails.root.join('tmp', 'copilot_translation.lock')
+    def ai_lock_path
+      Rails.root.join('tmp', 'ai_translation.lock')
     end
 
     # rubocop:disable Naming/PredicateMethod
-    def acquire_copilot_lock
-      lockfile = copilot_lock_path
+    def acquire_ai_lock
+      lockfile = ai_lock_path
 
       # Check if lock exists and handle stale locks
       if File.exist?(lockfile)
@@ -362,8 +380,8 @@ module MachineTranslationHelpers
     end
     # rubocop:enable Naming/PredicateMethod
 
-    def release_copilot_lock
-      FileUtils.rm_f(copilot_lock_path)
+    def release_ai_lock
+      FileUtils.rm_f(ai_lock_path)
     end
 
     def language_name(locale)
@@ -379,22 +397,22 @@ module MachineTranslationHelpers
       puts
     end
 
-    # Copilot-specific: Create empty target file for Copilot to fill
-    # Copilot needs an empty structure showing what keys to translate
-    def export_for_copilot(locale, keys)
+    # AI-specific: Create empty target file for the AI tool to fill in
+    # An empty structure shows the AI tool exactly what keys to translate
+    def export_for_ai(locale, keys)
       # Use generic export which creates source file and examples
       export_result = export_keys_for_translation(locale, keys)
 
-      # Create empty target file with just the key structure for Copilot
+      # Create empty target file with just the key structure for the AI tool
       tmp_dir = Rails.root.join('tmp')
       timestamp = export_result[:timestamp]
       target_output = { locale => {} }
       keys.each { |key| set_nested_key(target_output[locale], key, '') }
-      target_name = "copilot_target_#{locale}_#{timestamp}.yml"
+      target_name = "ai_target_#{locale}_#{timestamp}.yml"
       target_file = tmp_dir.join(target_name)
       File.write(target_file, yaml_dump(target_output))
 
-      # Return combined result for Copilot
+      # Return combined result for the AI tool
       {
         source: export_result[:filepath],         # Source English text
         target: target_file,                      # Empty target structure
@@ -483,8 +501,8 @@ module MachineTranslationHelpers
       end
     end
 
-    # Copilot-specific: Build prompt that references the instructions file
-    def build_copilot_prompt(locale, source_name, target_name, instructions_name)
+    # AI-specific: Build prompt that references the instructions file
+    def build_ai_prompt(locale, source_name, target_name, instructions_name)
       lang = language_name(locale)
 
       <<~PROMPT
@@ -517,7 +535,7 @@ module MachineTranslationHelpers
       PROMPT
     end
 
-    def run_copilot_translation(locale, batch_size: COPILOT_BATCH_SIZE)
+    def run_ai_translation(locale, batch_size: AI_BATCH_SIZE)
       missing_keys = find_untranslated_keys(locale)
       if missing_keys.empty?
         puts "No untranslated keys for #{locale}!"
@@ -527,18 +545,18 @@ module MachineTranslationHelpers
       keys_to_translate = missing_keys.first(batch_size)
       puts "Translating #{keys_to_translate.length} keys to #{language_name(locale)}..."
 
-      files = export_for_copilot(locale, keys_to_translate)
-      # Use basenames in prompt (copilot runs from tmp/ directory)
-      prompt = build_copilot_prompt(
+      files = export_for_ai(locale, keys_to_translate)
+      # Use basenames in prompt (the AI tool runs from the tmp/ directory)
+      prompt = build_ai_prompt(
         locale,
         files[:source_name],
         files[:target_name],
         files[:instructions_name]
       )
-      prompt_file = Rails.root.join('tmp', "copilot_prompt_#{locale}_#{files[:timestamp]}.txt")
+      prompt_file = Rails.root.join('tmp', "ai_prompt_#{locale}_#{files[:timestamp]}.txt")
       File.write(prompt_file, prompt)
 
-      # Print all inputs for insight into copilot translation
+      # Print all inputs for insight into the AI translation
       if files[:examples]
         print_file('Sample English translations (YAML)', files[:examples][:en_filepath])
         print_file("Sample #{language_name(locale)} translations (YAML)",
@@ -547,16 +565,16 @@ module MachineTranslationHelpers
       print_file('English to translate (YAML)', files[:source])
       print_file('Translation instructions', files[:instructions])
 
-      copilot_success = execute_copilot(prompt, files[:target])
+      ai_success = execute_ai(prompt, files[:target])
 
       # Print resulting translation for insight
       if File.exist?(files[:target])
         print_file("Resulting #{language_name(locale)} translation (YAML)", files[:target])
       end
 
-      # Try to import translations even if copilot had issues - use what we can
+      # Try to import translations even if the AI tool had issues - use what we can
       imported_count = false
-      if copilot_success && File.exist?(files[:target])
+      if ai_success && File.exist?(files[:target])
         imported_count = import_translations(locale, files[:target], expected_keys: keys_to_translate)
       end
 
@@ -966,22 +984,15 @@ module MachineTranslationHelpers
       text.scan(%r{https?://|www\.}).length
     end
 
-    # Copilot execution helpers
+    # AI CLI execution helpers
 
     # rubocop:disable Naming/PredicateMethod
-    def execute_copilot(prompt, target_file)
-      # Build copilot command with minimal permissions (read + write only)
-      # Runs from tmp/ directory so copilot can only access files there
-      cmd = [
-        'copilot',
-        '-p', prompt,
-        '--allow-tool', 'read',
-        '--allow-tool', 'write',
-        '--silent',
-        '--no-ask-user'
-      ]
+    def execute_ai(prompt, target_file)
+      # AI_CLI_ARGS carries the tool's own flags (see the constant comment
+      # above for why these aren't hardcoded here).
+      cmd = [AI_CLI, *Shellwords.split(AI_CLI_ARGS), '-p', prompt]
 
-      puts 'Running Copilot translation...'
+      puts "Running #{AI_CLI} translation..."
       # Run from tmp/ directory to restrict file access to only that directory
       result = Dir.chdir(Rails.root.join('tmp')) { system(*cmd) }
 
@@ -1022,7 +1033,7 @@ module MachineTranslationHelpers
       end
     end
 
-    # Fix common YAML quoting issues in Copilot output
+    # Fix common YAML quoting issues in AI-generated output
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def fix_yaml_quoting(content, _locale)
       lines = content.split("\n")

--- a/lib/tasks/machine_translations.rake
+++ b/lib/tasks/machine_translations.rake
@@ -10,7 +10,7 @@
 # translations aren't yet available. The workflow is:
 #
 # 1. Export untranslated keys: rake translation:export[fr,50]
-# 2. Translate that file using any tool (Copilot, ChatGPT, human, etc.)
+# 2. Translate that file using any tool (an AI CLI, ChatGPT, human, etc.)
 # 3. Import the translated file: rake translation:import[fr,tmp/file.yml]
 # 4. Periodically clean up: rake translation:cleanup
 #
@@ -76,19 +76,19 @@ namespace :translation do
     MachineTranslationHelpers.print_status
   end
 
-  desc 'Run automated translation via GitHub Copilot (safe for cron/timer)'
-  task :copilot, %i[locale count] => :environment do |_t, args|
-    unless MachineTranslationHelpers.acquire_copilot_lock
-      puts 'Another Copilot translation is in progress. Skipping.'
+  desc 'Run automated translation via an AI CLI tool (safe for cron/timer)'
+  task :ai, %i[locale count] => :environment do |_t, args|
+    unless MachineTranslationHelpers.acquire_ai_lock
+      puts 'Another AI translation is in progress. Skipping.'
       next
     end
 
     begin
       locale = args[:locale] || MachineTranslationHelpers.next_locale_needing_translation
-      count = (args[:count] || MachineTranslationHelpers::COPILOT_BATCH_SIZE).to_i
+      count = (args[:count] || MachineTranslationHelpers::AI_BATCH_SIZE).to_i
       MachineTranslationHelpers.validate_locale!(locale)
 
-      result = MachineTranslationHelpers.run_copilot_translation(locale, batch_size: count)
+      result = MachineTranslationHelpers.run_ai_translation(locale, batch_size: count)
 
       if result[:success]
         puts "Successfully translated #{result[:translated]} keys for #{result[:locale]}"
@@ -98,13 +98,13 @@ namespace :translation do
         exit 1
       end
     ensure
-      MachineTranslationHelpers.release_copilot_lock
+      MachineTranslationHelpers.release_ai_lock
     end
   end
 
   desc 'Translate all missing/obsolete segments in all locales (runs until complete)'
   task :all, [:batch_size] => :environment do |_t, args|
-    batch_size = (args[:batch_size] || MachineTranslationHelpers::COPILOT_BATCH_SIZE).to_i
+    batch_size = (args[:batch_size] || MachineTranslationHelpers::AI_BATCH_SIZE).to_i
     wait_time = 10 # Seconds to wait between batches
 
     puts 'Starting automated machine translation for all locales...'
@@ -140,11 +140,11 @@ namespace :translation do
       # Run translation for this locale, catching any exit/failure
       puts "Translating batch of #{[batch_size, missing_keys.length].min} keys..."
       begin
-        Rake::Task['translation:copilot'].reenable # Allow task to be called again
-        Rake::Task['translation:copilot'].invoke(locale, batch_size)
+        Rake::Task['translation:ai'].reenable # Allow task to be called again
+        Rake::Task['translation:ai'].invoke(locale, batch_size)
       rescue SystemExit => e
-        # Copilot task exited with error - log it but continue
-        puts "Copilot task exited with status #{e.status} - continuing anyway..."
+        # AI translation task exited with error - log it but continue
+        puts "AI translation task exited with status #{e.status} - continuing anyway..."
       end
 
       # Check if we made progress (even partial success counts)


### PR DESCRIPTION
We lost access to GitHub Copilot CLI, which the translation:copilot rake task and its helpers called by name throughout (method names, a lock file, temp file names). Rename everything to generic ai_*/AI_* naming (rake translation:ai replaces translation:copilot) and drive the actual CLI invocation from three environment variables:

- BADGEAPP_TRANSLATION_AI_CLI (default: claude) - the executable to run
- BADGEAPP_TRANSLATION_AI_MODEL (default: sonnet)
- BADGEAPP_TRANSLATION_AI_ARGS - full flag list (default: read/write-only tool access, confined to tmp/, edits auto-accepted, no session saved)

This way, losing access to one tool again means changing configuration, not renaming identifiers throughout the codebase. Verified end-to-end with rake translation:ai[fr,3]: confirmed the sandboxing (can't read outside tmp/, can't run shell commands) and confirmed it produces correct, valid translations, which are included here.


Claude-Session: https://claude.ai/code/session_01DijGYkCYuM4MBrKanansoX
Assisted-by: Claude:claude-sonnet-5