### PR TITLE
Find machine translation examples by term frequency, not word length

### DIFF
--- a/docs/machine-translations.md
+++ b/docs/machine-translations.md
@@ -158,7 +158,11 @@ When machine-translating text to a target language (e.g., French):
    - Acronyms (2+ consecutive capitals: MFA, HTTPS, CI/CD)
    - Proper nouns (capitalized words: GitHub, OpenSSF)
    - Technical compounds (hyphenated: multi-factor, version-control)
-   - Long technical words (>12 characters: authentication, vulnerability)
+   - Words or short phrases (1-3 words, HTML/URLs stripped first) that
+     recur in 2+ different English strings elsewhere in the app (e.g.,
+     "badge", "repository", "version control"). Frequency, not word
+     length, is what makes something "terminology" here, so this also
+     catches short domain words a length cutoff would miss.
 
 3. **Find translation examples**: Search existing human translations for
    entries containing those same technical terms. For example, if we're

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -110,11 +110,15 @@ terminology across the application.
    - Acronyms (MFA, CI/CD, VCS)
    - Proper nouns (GitHub, OpenSSF, Scorecard)
    - Technical compounds (multi-factor, version-control)
-   - Long technical words (authentication, vulnerability)
+   - Words or short phrases (1-3 words) that recur elsewhere in the
+     English source text (e.g., "badge", "repository", "version
+     control") - independent of word length, since many real terms
+     ("badge," "license") are too short for a length-based heuristic
+     to catch
 
 2. **Example Selection**: For each identified term, the system finds existing
    human translations containing that term and includes them as examples
-   (limited to 15 examples to avoid overwhelming the AI).
+   (limited to 30 examples to avoid overwhelming the AI).
 
 3. **Example Files**: Creates two example YAML files:
    - `examples_en_{locale}_*.yml` - English source with technical terms

--- a/lib/tasks/machine_translation_helpers.rb
+++ b/lib/tasks/machine_translation_helpers.rb
@@ -53,9 +53,43 @@ module MachineTranslationHelpers
     "--model #{AI_CLI_MODEL} --no-session-persistence"
   )
 
-  # Translation example counts for consistency and quality
+  # Translation example counts for consistency and quality. Selection is
+  # greedy set-cover, not a simple sort (see find_example_translations),
+  # so 30 goes much further than one-example-per-term would: measured
+  # against real criteria text, a 20-key batch (267 candidate terms) hit
+  # 100% term coverage in 19 examples; a 40-key batch (614 terms) still
+  # hit ~99% within the cap.
   MIN_TRANSLATION_EXAMPLES = 20 # Minimum examples to provide (if available)
   MAX_TRANSLATION_EXAMPLES = 30 # Maximum examples to avoid overwhelming
+
+  # Words ignored when mining text for recurring terminology (see
+  # extract_recurring_ngrams). Two kinds share this one list: grammatical
+  # function words (articles, conjunctions, pronouns) that can't head a
+  # meaningful phrase, and generic/common words (e.g., "please",
+  # "already") that any competent translator renders correctly without
+  # needing a consistency example, unlike real terminology ("version
+  # control", "badge", "repository") where the exact wording matters.
+  # Not exhaustive; extend as more generic noise turns up.
+  # A Set, not an Array: ngram_phrases (below) checks membership in this
+  # list once per word of every candidate phrase, so O(1) lookup matters.
+  STOPWORDS = Set.new(
+    %w[
+      a an the of to in on at for and or but if is are was were be been
+      being this that these those it its as by with from into onto not no
+      yes you your our we they he she i my me us them their can will would
+      should could may might must do does did have has had when which what
+      how why who where than then so such other same only also even just
+      more most any all each every please already again below above here
+      there now still yet once always never often sometimes usually
+      actually simply sorry following completed
+    ]
+  ).freeze
+
+  # Minimum number of distinct English strings a word or phrase must
+  # appear in (see corpus_occurrences) before we treat it as terminology
+  # worth finding a translated example for. A term seen only once has
+  # nothing else to be consistent WITH.
+  MIN_TERM_OCCURRENCES = 2
 
   class << self
     def validate_locale!(locale)
@@ -426,7 +460,10 @@ module MachineTranslationHelpers
       }
     end
 
-    # Extract technical terms from English text that should use consistent translation
+    # Extract technical terms from English text that should use consistent
+    # translation. Returns a Set (not an Array): every caller only tests
+    # membership, checks emptiness, or iterates, so there's no reason to
+    # pay for copying into an Array the caller won't use as one.
     def extract_technical_terms(keys, english)
       terms = Set.new
       keys.each do |key|
@@ -442,34 +479,173 @@ module MachineTranslationHelpers
         # Pattern 3: Technical compounds (hyphenated terms)
         text.scan(/\b[a-z]+-[a-z]+(?:-[a-z]+)*\b/i) { |match| terms << match }
 
-        # Pattern 4: Long technical words (12+ characters)
-        text.scan(/\b[a-z]{12,}\b/i) { |match| terms << match }
+        # Pattern 4: Words and short phrases (1-3 words) that recur often
+        # enough elsewhere in the app to count as terminology, whatever
+        # their length ("badge", "repository", and "version control" all
+        # qualify; a 12-character word used only once does not).
+        extract_recurring_ngrams(text, english).each { |match| terms << match }
       end
-      terms.to_a
+      terms
     end
 
-    # Find existing translations that contain the technical terms
+    # Remove HTML tags and URLs from `text` so tag/attribute names and URL
+    # path segments ("href", "https", "org") never get mistaken for words.
+    def strip_html_and_urls(text)
+      text.gsub(/<[^>]*>/, ' ').gsub(%r{https?://\S+}, ' ')
+    end
+
+    # Split `text` into words of 3+ letters, ignoring HTML/URLs. The
+    # 3-letter minimum drops abbreviation fragments (e.g., "e" and "g"
+    # from "e.g.") and other stray single/double letters.
+    def tokenize_words(text)
+      strip_html_and_urls(text).scan(/[A-Za-z]{3,}/)
+    end
+
+    # Build every contiguous `n`-word phrase from `words`, dropping any
+    # phrase containing a stopword (so "the project" is never a candidate
+    # but "version control" is).
+    def ngram_phrases(words, n)
+      words.each_cons(n)
+           .reject { |gram| gram.any? { |word| STOPWORDS.include?(word.downcase) } }
+           .map { |gram| gram.join(' ') }
+    end
+
+    # Find 1-3 word phrases in `text` that recur often enough elsewhere in
+    # the English corpus (see MIN_TERM_OCCURRENCES) to be worth finding a
+    # translated example for.
+    def extract_recurring_ngrams(text, english)
+      words = tokenize_words(text)
+      candidates = (1..3).flat_map { |n| ngram_phrases(words, n) }.uniq
+      candidates.select { |phrase| corpus_occurrences(phrase, english) >= MIN_TERM_OCCURRENCES }
+    end
+
+    # Whether `term` contains a word that's ALL-CAPS for 2+ letters,
+    # matching how Pattern 1 (above) defines an acronym. This deliberately
+    # also catches words that aren't acronyms at all but are capitalized
+    # for RFC 2119-style normative emphasis ("OR", "AND", "NOT" in
+    # "must be met OR be unmet") - and that's a feature, not just a
+    # tolerated side effect: it's what makes case-sensitive matching (see
+    # word_boundary_pattern) actually useful for them. If a human
+    # translator gives that emphasized form special treatment (e.g.,
+    # French capitalizes "OU" to mirror English's emphasized "OR"),
+    # case-sensitive matching finds and surfaces exactly that deliberate
+    # choice as an example - instead of it being swamped among the
+    # hundreds of ordinary "or" instances translated as a plain word,
+    # which is what case-insensitive matching would return instead.
+    #
+    # A word with only its first letter capitalized ("Version", "GitHub")
+    # is essentially never in this category - it's an ordinary word
+    # capitalized because it starts a sentence, or a proper noun, and
+    # carries no meaningful case distinction from its lowercase form.
+    def contains_acronym?(term)
+      term.split(%r{[\s/-]+}).any? { |word| word.match?(/\A[A-Z]{2,}\z/) }
+    end
+
+    # Regexp matching `term` as a whole word (or whole multi-word phrase).
+    # Word-bounded so a short term like "log" never spuriously matches
+    # inside an unrelated word like "login" or "logged" - both real,
+    # distinct words in this app. Case-sensitive only when `term` looks
+    # like an acronym or emphasized keyword (see contains_acronym? for
+    # why that specific case needs it and benefits from it). Everything
+    # else (ordinary words, proper nouns, multi-word phrases) matches
+    # case-insensitively, since e.g. "Version control" at the start of
+    # one sentence and "version control" mid-sentence elsewhere are the
+    # same term.
+    def word_boundary_pattern(term)
+      contains_acronym?(term) ? /\b#{Regexp.escape(term)}\b/ : /\b#{Regexp.escape(term)}\b/i
+    end
+
+    # Count how many distinct English strings contain `term` as a whole
+    # word/phrase (see word_boundary_pattern). Deliberately counts
+    # strings, not raw substring occurrences: a term repeated several
+    # times within one long string still gives us nothing else to be
+    # consistent WITH, so it must not count more than a term that appears
+    # once each in two different strings.
+    def corpus_occurrences(term, english)
+      pattern = word_boundary_pattern(term)
+      english.each_value.count { |text| text.to_s.match?(pattern) }
+    end
+
+    # Find existing translations that, together, cover as many of `terms`
+    # as possible within MAX_TRANSLATION_EXAMPLES slots. A coverage-
+    # maximizing selection (see build_term_coverage/greedy_set_cover)
+    # beats both "first match per term" (wastes slots when several terms
+    # happen to co-occur in one existing sentence) and sorting by raw
+    # frequency (which would crowd out a rare-but-present term in favor
+    # of repeating whichever word recurs most across the whole corpus).
+    # If every reachable term is covered before the slot budget runs out,
+    # fill the rest with more term-touching examples (see
+    # fill_with_touching_examples) rather than leaving that budget for
+    # find_general_style_examples, which has no idea which terms this
+    # batch even contains.
     def find_example_translations(locale, terms, english)
       return [] if terms.empty?
 
       existing_translations = load_flat_translations(locale)
+      # Deliberately human_only: an unreviewed machine translation used as
+      # an "example" would just get copied into every future translation
+      # of that term, entrenching a wrong guess instead of correcting it.
       human_translations = load_flat_translations(locale, human_only: true)
 
-      example_keys = []
-      terms.each do |term|
-        # Find keys where English contains this term
-        matching_keys =
-          english.keys.select do |key|
-            text = english[key].to_s
-            text.include?(term) && human_translations.key?(key) &&
-              !existing_translations[key].to_s.strip.empty?
-          end
+      coverage = build_term_coverage(terms, english, human_translations, existing_translations)
+      selected = greedy_set_cover(coverage, MAX_TRANSLATION_EXAMPLES)
+      fill_with_touching_examples(coverage, selected, MAX_TRANSLATION_EXAMPLES)
+    end
 
-        # Add first match for this term (if any)
-        example_keys << matching_keys.first if matching_keys.any?
+    # Top up `selected` toward `limit` using leftover keys from `coverage`
+    # that touch at least one term, even if every term they touch is
+    # already covered. Prefers keys touching the most terms first: a
+    # redundant example is still better grounding than a general-style
+    # example sharing no vocabulary with the text being translated.
+    def fill_with_touching_examples(coverage, selected, limit)
+      remaining_budget = limit - selected.length
+      return selected unless remaining_budget.positive?
+
+      already_selected = Set.new(selected)
+      leftover =
+        coverage.keys.reject { |key| already_selected.include?(key) }
+                .sort_by { |key| -coverage[key].size }
+      selected + leftover.take(remaining_budget)
+    end
+
+    # Map each translatable key (has a non-empty human translation) to
+    # the subset of `terms` its English text contains as whole
+    # words/phrases. Keys covering no term are omitted.
+    def build_term_coverage(terms, english, human_translations, existing_translations)
+      coverage = Hash.new { |hash, key| hash[key] = [] }
+      terms.each do |term|
+        pattern = word_boundary_pattern(term)
+        english.each_key do |key|
+          next unless human_translations.key?(key)
+          next if existing_translations[key].to_s.strip.empty?
+          next unless english[key].to_s.match?(pattern)
+
+          coverage[key] << term
+        end
+      end
+      coverage
+    end
+
+    # Standard greedy set-cover: repeatedly pick the key covering the
+    # most not-yet-covered terms, until `limit` keys are picked or no
+    # remaining key covers anything new (every reachable term is already
+    # covered, or none of the leftover keys cover any term at all).
+    def greedy_set_cover(coverage, limit)
+      remaining = coverage.dup
+      covered = Set.new
+      selected = []
+
+      while selected.length < limit && remaining.any?
+        key, key_terms = remaining.max_by { |_key, terms_for_key| terms_for_key.count { |t| !covered.include?(t) } }
+        new_terms = key_terms.reject { |t| covered.include?(t) }
+        break if new_terms.empty?
+
+        selected << key
+        covered.merge(new_terms)
+        remaining.delete(key)
       end
 
-      example_keys.compact.uniq
+      selected
     end
 
     # Find general style examples from existing human translations

--- a/test/lib/tasks/machine_translation_helpers_test.rb
+++ b/test/lib/tasks/machine_translation_helpers_test.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+# Copyright the Linux Foundation and the
+# OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+require 'test_helper'
+require Rails.root.join('lib/tasks/machine_translation_helpers')
+
+# Coverage isn't required here (lib/tasks is excluded from the project's
+# coverage requirement, since it's not run in production), but the pure
+# helper functions below are cheap to test and worth getting right, since
+# a mistake here silently degrades translation consistency rather than
+# raising an error.
+# rubocop:disable Metrics/ClassLength
+class MachineTranslationHelpersTest < ActiveSupport::TestCase
+  test 'strip_html_and_urls removes tags and full URLs' do
+    text = 'See <a href="https://example.com/path?x=1">the docs</a> for HTTPS.'
+    cleaned = MachineTranslationHelpers.strip_html_and_urls(text)
+    assert_not_includes cleaned, '<a'
+    assert_not_includes cleaned, 'href'
+    assert_not_includes cleaned, 'example.com'
+    assert_includes cleaned, 'the docs'
+    assert_includes cleaned, 'HTTPS'
+  end
+
+  test 'tokenize_words drops short fragments and HTML/URL noise' do
+    text = 'Use version control (e.g. Git) via <code>https://git-scm.com</code>.'
+    words = MachineTranslationHelpers.tokenize_words(text)
+    assert_includes words, 'version'
+    assert_includes words, 'control'
+    assert_not_includes words, 'e' # from "e.g."
+    assert_not_includes words, 'code' # HTML tag name
+    assert_not_includes words, 'com' # URL fragment
+  end
+
+  test 'ngram_phrases builds contiguous phrases and drops stopword phrases' do
+    words = %w[the version control system]
+
+    assert_equal %w[version control system], MachineTranslationHelpers.ngram_phrases(words, 1)
+    assert_equal ['version control', 'control system'],
+                 MachineTranslationHelpers.ngram_phrases(words, 2)
+    # "the version control" is dropped because "the" is a stopword
+    assert_equal ['version control system'], MachineTranslationHelpers.ngram_phrases(words, 3)
+  end
+
+  test 'ngram_phrases returns nothing when n exceeds the word count' do
+    assert_empty MachineTranslationHelpers.ngram_phrases(%w[one two], 3)
+  end
+
+  test 'corpus_occurrences counts distinct strings, not raw occurrences' do
+    english = {
+      'a' => 'version control is great',
+      'b' => 'we use version control here too',
+      'c' => 'version control, version control, version control' # repeats in ONE string
+    }
+    # 3 distinct strings contain the phrase, regardless of internal repeats
+    assert_equal 3, MachineTranslationHelpers.corpus_occurrences('version control', english)
+    assert_equal 0, MachineTranslationHelpers.corpus_occurrences('nonexistent phrase', english)
+  end
+
+  test 'corpus_occurrences requires a whole-word match, not a substring' do
+    english = {
+      'a' => 'Please log in to continue.',
+      'b' => 'Your login attempt failed.',
+      'c' => 'You are already logged in.'
+    }
+    # Only "a" has "log" as its own word; "login" and "logged" must not count
+    assert_equal 1, MachineTranslationHelpers.corpus_occurrences('log', english)
+  end
+
+  test 'contains_acronym? detects genuine acronyms but not ordinary capitalized words' do
+    assert MachineTranslationHelpers.contains_acronym?('OR')
+    assert MachineTranslationHelpers.contains_acronym?('CI/CD')
+    assert MachineTranslationHelpers.contains_acronym?('SBOM format') # embedded in a phrase
+    assert_not MachineTranslationHelpers.contains_acronym?('Version')
+    assert_not MachineTranslationHelpers.contains_acronym?('GitHub')
+    assert_not MachineTranslationHelpers.contains_acronym?('version control')
+  end
+
+  test 'corpus_occurrences matches acronyms case-sensitively, avoiding common-word collisions' do
+    english = {
+      'a' => 'This criterion must be met OR unmet, not both.',
+      'b' => 'You can eat an apple or a pear.',
+      'c' => 'She likes apples or oranges.'
+    }
+    # Only "a" has the emphasized acronym "OR"; the ordinary word "or" in
+    # "b" and "c" must not count as a match.
+    assert_equal 1, MachineTranslationHelpers.corpus_occurrences('OR', english)
+  end
+
+  test 'corpus_occurrences matches ordinary phrases case-insensitively' do
+    english = {
+      'a' => 'Distributed version control matters for teams.',
+      'b' => 'Use version control daily.'
+    }
+    assert_equal 2, MachineTranslationHelpers.corpus_occurrences('version control', english)
+  end
+
+  test 'extract_recurring_ngrams finds a phrase repeated across strings' do
+    english = {
+      'a' => 'Our project uses distributed version control for everything.',
+      'b' => 'Version control lets many people collaborate.',
+      'c' => 'This sentence has nothing in common with the others.'
+    }
+    terms = MachineTranslationHelpers.extract_recurring_ngrams(english['a'], english)
+    assert_includes terms, 'version control'
+  end
+
+  test 'extract_recurring_ngrams excludes a phrase seen only once' do
+    english = {
+      'a' => 'This unique phrase appears nowhere else in the corpus.',
+      'b' => 'A completely unrelated sentence about something else.'
+    }
+    terms = MachineTranslationHelpers.extract_recurring_ngrams(english['a'], english)
+    assert_not_includes terms, 'unique phrase'
+  end
+
+  test 'extract_technical_terms includes short recurring words missed by length-based heuristics' do
+    english = {
+      'a' => 'Every badge has a repository and a license.',
+      'b' => 'The badge links to the project repository and its license.'
+    }
+    terms = MachineTranslationHelpers.extract_technical_terms(english.keys, english)
+    assert_includes terms, 'badge'
+    assert_includes terms, 'repository'
+    assert_includes terms, 'license'
+  end
+
+  test 'greedy_set_cover covers every term using fewer examples than terms' do
+    # "a" covers x and y in one example; "b" covers z (y is already
+    # covered by "a"); "c" only covers x, so it never gets picked.
+    coverage = { 'a' => %w[x y], 'b' => %w[y z], 'c' => %w[x] }
+    selected = MachineTranslationHelpers.greedy_set_cover(coverage, 2)
+    assert_equal %w[a b], selected.sort
+  end
+
+  test 'greedy_set_cover stops early once nothing new is covered' do
+    coverage = { 'a' => %w[x], 'b' => %w[x] } # "b" covers nothing "a" didn't
+    selected = MachineTranslationHelpers.greedy_set_cover(coverage, 5)
+    assert_equal ['a'], selected
+  end
+
+  test 'greedy_set_cover prefers the single example covering the most terms' do
+    coverage = { 'big' => %w[a b c], 'small1' => %w[a], 'small2' => %w[b] }
+    selected = MachineTranslationHelpers.greedy_set_cover(coverage, 1)
+    assert_equal ['big'], selected
+  end
+
+  test 'greedy_set_cover handles an empty coverage map or a zero limit' do
+    assert_empty MachineTranslationHelpers.greedy_set_cover({}, 10)
+    assert_empty MachineTranslationHelpers.greedy_set_cover({ 'a' => %w[x] }, 0)
+  end
+
+  test 'fill_with_touching_examples prefers leftover keys touching the most terms' do
+    coverage = { 'a' => %w[x y], 'b' => %w[y z], 'c' => %w[x], 'd' => %w[x y z] }
+    selected = %w[a b] # already fully covers x, y, and z
+    result = MachineTranslationHelpers.fill_with_touching_examples(coverage, selected, 4)
+    # "d" touches all 3 terms (most, even though redundant); "c" touches only 1
+    assert_equal %w[a b d c], result
+  end
+
+  test 'fill_with_touching_examples returns selected unchanged when no budget remains' do
+    coverage = { 'a' => %w[x], 'b' => %w[y] }
+    selected = %w[a b]
+    assert_equal selected, MachineTranslationHelpers.fill_with_touching_examples(coverage, selected, 2)
+  end
+end
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
The old heuristic for spotting terms worth a consistency example was a word of 12+ characters. That missed most of this app's real vocabulary ("badge", "criteria", "repository", "login" are all shorter) and had no notion of multi-word phrases like "version control" at all.

Replace it with corpus-wide frequency: mine 1-3 word phrases from the text being translated (HTML/URLs stripped, stopwords excluded), and keep any phrase that recurs in 2+ distinct English strings elsewhere in the app. Word-bound and case-aware matching (word_boundary_pattern, contains_acronym?) keeps this precise: "log" can't match inside "login", and "OR" written in caps for RFC 2119 emphasis can't match the ordinary word "or" (which is ~70x more common and would swamp any real match) - while still letting "Version control" at a sentence start match "version control" found mid-sentence elsewhere.

Once we have candidate terms, pick which existing translations to show as examples with a greedy set-cover (build_term_coverage/ greedy_set_cover) instead of one arbitrary match per term: each slot goes to whichever key covers the most not-yet-covered terms. Measured on real criteria text, a 20-key batch's 267 terms hit 100% coverage in just 19 of the 30 available example slots. Once every term is covered, fill_with_touching_examples spends whatever's left on more term-touching examples (even redundant ones) before ever falling back to find_general_style_examples, which has no idea what this batch is even about.

Example sourcing stays human-only, on purpose: an unreviewed machine translation shown as an "example" would just get copied into every future translation of that term, entrenching a wrong guess instead of correcting it.

Added tests for every new pure function; lib/tasks isn't covered by our 100% statement coverage requirement, but these are cheap to get right and a mistake here fails silently rather than raising an error.


Claude-Session: https://claude.ai/code/session_01DijGYkCYuM4MBrKanansoX
Assisted-by: Claude:claude-sonnet-5