### PR TITLE
Fix stale-translation detection for keys with a blank human placeholder

### DIFF
--- a/lib/tasks/machine_translation_helpers.rb
+++ b/lib/tasks/machine_translation_helpers.rb
@@ -107,6 +107,20 @@ module MachineTranslationHelpers
       Rails.root.join('config', 'machine_translations', "src_en_#{locale}.yml")
     end
 
+    # Whether `human_translations` has a REAL (non-blank) value for
+    # `key`, not just an entry for it. translation.io exports every
+    # tracked segment with a blank placeholder until a human actually
+    # translates it, so mere key presence (`human_translations.key?`)
+    # doesn't mean a human translation exists. Treating presence alone as
+    # "translated" was a real bug: it let a key with a blank human
+    # placeholder, but an existing machine translation, silently skip
+    # staleness detection when the English source changed - and
+    # separately, let that same machine translation (of possibly-stale
+    # English) be picked as if it were a trustworthy human example.
+    def human_translation_present?(human_translations, key)
+      !human_translations[key].to_s.strip.empty?
+    end
+
     def find_untranslated_keys(locale)
       english = load_flat_translations('en')
       translated = load_flat_translations(locale)
@@ -127,7 +141,7 @@ module MachineTranslationHelpers
         # 1. No translation exists or is empty, OR
         # 2. English source has changed since machine translation (and no human translation)
         next true if value.nil? || value.to_s.strip.empty?
-        next false if human_translated.key?(key) # Has human translation - ignore source changes
+        next false if human_translation_present?(human_translated, key) # ignore source changes
 
         # Check if English source has changed since machine translation
         source_tracking.key?(key) && source_tracking[key] != english_value
@@ -616,7 +630,7 @@ module MachineTranslationHelpers
       terms.each do |term|
         pattern = word_boundary_pattern(term)
         english.each_key do |key|
-          next unless human_translations.key?(key)
+          next unless human_translation_present?(human_translations, key)
           next if existing_translations[key].to_s.strip.empty?
           next unless english[key].to_s.match?(pattern)
 
@@ -658,7 +672,8 @@ module MachineTranslationHelpers
       # Get all available human translation keys
       available_keys =
         human_translations.keys.reject do |key|
-          exclude.include?(key) || existing_translations[key].to_s.strip.empty?
+          exclude.include?(key) || !human_translation_present?(human_translations, key) ||
+            existing_translations[key].to_s.strip.empty?
         end
 
       # Sort by text length (prefer shorter, clearer examples)

--- a/lib/tasks/machine_translation_helpers.rb
+++ b/lib/tasks/machine_translation_helpers.rb
@@ -110,13 +110,8 @@ module MachineTranslationHelpers
     # Whether `human_translations` has a REAL (non-blank) value for
     # `key`, not just an entry for it. translation.io exports every
     # tracked segment with a blank placeholder until a human actually
-    # translates it, so mere key presence (`human_translations.key?`)
-    # doesn't mean a human translation exists. Treating presence alone as
-    # "translated" was a real bug: it let a key with a blank human
-    # placeholder, but an existing machine translation, silently skip
-    # staleness detection when the English source changed - and
-    # separately, let that same machine translation (of possibly-stale
-    # English) be picked as if it were a trustworthy human example.
+    # translates it, so mere key existence (`human_translations.key?`)
+    # doesn't mean a human translation was created.
     def human_translation_present?(human_translations, key)
       !human_translations[key].to_s.strip.empty?
     end

--- a/test/lib/tasks/machine_translation_helpers_test.rb
+++ b/test/lib/tasks/machine_translation_helpers_test.rb
@@ -165,5 +165,20 @@ class MachineTranslationHelpersTest < ActiveSupport::TestCase
     selected = %w[a b]
     assert_equal selected, MachineTranslationHelpers.fill_with_touching_examples(coverage, selected, 2)
   end
+
+  test 'human_translation_present? is false for a key present but blank' do
+    # translation.io exports every tracked segment with a blank
+    # placeholder until a human actually translates it, so the key
+    # existing in the hash does not mean a human translation exists.
+    human_translations = { 'osps_gv_02_01.description' => nil, 'osps_gv_02_01.details' => '' }
+    assert_not MachineTranslationHelpers.human_translation_present?(human_translations, 'osps_gv_02_01.description')
+    assert_not MachineTranslationHelpers.human_translation_present?(human_translations, 'osps_gv_02_01.details')
+  end
+
+  test 'human_translation_present? is true only for a real, non-blank value' do
+    human_translations = { 'sessions.signed_in' => 'Connecte !' }
+    assert MachineTranslationHelpers.human_translation_present?(human_translations, 'sessions.signed_in')
+    assert_not MachineTranslationHelpers.human_translation_present?(human_translations, 'no_such_key')
+  end
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
translation.io exports every tracked segment into translation.*.yml with a blank placeholder until a human actually translates it. Three places in the machine-translation pipeline treated a key's mere presence in the human-translations hash as "has a human translation," when the value could be blank: find_untranslated_keys, build_term_coverage, and find_general_style_examples.

The practical effect: when only a machine translation exists for a key (the human slot is blank) and the English source later changes, find_untranslated_keys never noticed, because it stopped checking staleness as soon as it saw the (blank) human entry. Concretely, criteria.baseline-1.osps_gv_02_01.description still carries a French machine translation of the pre-baseline-update English ("While active, the project MUST have...") with no way for our tooling to ever flag it for retranslation. Rerunning find_untranslated_keys across all 8 locales after this fix turned up 31-32 more stale keys per locale that were silently invisible before - almost certainly most of the 26 criteria we reworded in the last baseline update.

This also affected the term-extraction/example-selection work from the previous commit: build_term_coverage and find_general_style_examples could both pick a blank-human-but-machine-filled key as a "human" example, handing the AI a possibly-stale machine translation as if it were vetted - exactly what the human_only sourcing was supposed to rule out.

Fixed with one shared predicate, human_translation_present?, used at all three call sites instead of the bare .key? check. Left merge_flat! (the shared YAML flattener) alone: the import-validation path also uses it and has a legitimate, different reason to track a blank AI-provided translation as "present but blank" for its own diagnostics, so fixing this at that shared layer would have been a regression there.

Verified against the real corpus: osps_gv_02_01 is now correctly flagged as needing retranslation, and a live run of the full extraction/ selection pipeline confirms zero selected examples are blank-human/ machine-filled keys anymore.


Claude-Session: https://claude.ai/code/session_01DijGYkCYuM4MBrKanansoX
Assisted-by: Claude:claude-sonnet-5