### PR TITLE
Update stale French machine translations after baseline criteria reword

### DIFF
--- a/config/machine_translations/fr.yml
+++ b/config/machine_translations/fr.yml
@@ -103,6 +103,10 @@ fr:
     warned_level_message: |-
       Ceci est un avis préalable que le badge "%{old_level}" de votre projet pourrait être perdu le %{effective_date} lors de l'entrée en vigueur des critères mis à jour.
       Veuillez consulter votre entrée de badge à l'URL suivante avant cette date :
+    warned_level_message_no_date: |-
+      Ceci est un avis préalable indiquant que le badge "%{old_level}" de votre projet peut
+      être perdu lorsque les critères mis à jour entreront en vigueur.
+      Veuillez consulter votre entrée de badge à l'URL suivante :
   criteria:
     baseline-1:
       osps_ac_01_01:
@@ -118,7 +122,7 @@ fr:
         description: Lorsqu'une tentative est faite de supprimer la branche principale du projet, le système de contrôle de version DOIT traiter cela comme une activité sensible et exiger une confirmation explicite de l'intention.
         details: Définissez une protection de branche sur la branche principale dans le système de contrôle de version du projet pour empêcher la suppression.
       osps_br_01_01:
-        description: Lorsqu'un pipeline CI/CD accepte un paramètre d'entrée, ce paramètre DOIT être assaini et validé avant d'être utilisé dans le pipeline.
+        description: Lorsqu'un pipeline CI/CD fonctionne sur des métadonnées non fiables, ces paramètres DOIVENT être nettoyés et validés avant d'être utilisés dans le pipeline.
         details: Les pipelines CI/CD doivent assainir (mettre entre guillemets, échapper ou quitter pour les valeurs attendues) toutes les entrées de métadonnées correspondant à des sources non fiables. Cela inclut des données telles que les noms de branches, les messages de commit, les tags, les titres des pull requests et les informations sur l'auteur.
       osps_br_01_02:
         description: Lorsqu'un pipeline CI/CD utilise un nom de branche dans sa fonctionnalité, cette valeur de nom DOIT être assainie et validée avant d'être utilisée dans le pipeline.
@@ -126,8 +130,8 @@ fr:
         description: Lorsque le projet liste un URI comme canal officiel du projet, cet URI DOIT être exclusivement fourni en utilisant des canaux chiffrés.
         details: Configurez les sites Web et les systèmes de contrôle de version du projet pour utiliser des canaux chiffrés tels que SSH ou HTTPS pour la transmission de données. Assurez-vous que tous les outils et domaines référencés dans la documentation du projet ne peuvent être accessibles que via des canaux chiffrés.
       osps_br_03_02:
-        description: Lorsque le projet liste un URI comme canal de distribution officiel, cet URI DOIT être exclusivement fourni en utilisant des canaux chiffrés.
-        details: Configurez le pipeline de publication du projet pour récupérer uniquement les données des sites Web, réponses API et autres services qui utilisent des canaux chiffrés tels que SSH ou HTTPS pour la transmission de données.
+        description: Lorsque le projet répertorie une URI comme canal de distribution officiel, ce canal DOIT être protégé contre les attaques de l'adversaire au milieu (adversary-in-the-middle) à l'aide de canaux authentifiés cryptographiquement.
+        details: Les artefacts distribués par le projet devraient être distribués par des canaux qui garantissent l'intégrité et l'authenticité. L'utilisation de HTTPS pour les téléchargements, de versions signées ou de la distribution via des gestionnaires de paquets fiables sont toutes des méthodes acceptables pour se protéger contre les attaques de l'adversaire au milieu.
       osps_br_07_01:
         description: Le projet DOIT empêcher le stockage involontaire de données sensibles non chiffrées, telles que des secrets et des informations d'identification, dans le système de contrôle de version.
         details: Configurez .gitignore ou équivalent pour exclure les fichiers susceptibles de contenir des informations sensibles. Utilisez des hooks de pré-commit et des outils d'analyse automatisés pour détecter et empêcher l'inclusion de données sensibles dans les commits.
@@ -138,25 +142,25 @@ fr:
         description: Lorsque le projet a effectué une publication, la documentation du projet DOIT inclure un guide pour signaler les défauts.
         details: Il est recommandé que les projets utilisent le suivi de problèmes par défaut de leur VCS. Si une source externe est utilisée, assurez-vous que la documentation du projet et le guide de contribution expliquent clairement et visiblement comment utiliser le système de signalement. Il est recommandé que la documentation du projet établisse également des attentes quant à la manière dont les défauts seront triés et résolus.
       osps_gv_02_01:
-        description: Tant qu'il est actif, le projet DOIT avoir un ou plusieurs mécanismes pour des discussions publiques sur les modifications proposées et les obstacles d'utilisation.
+        description: Le projet DOIT disposer d'un ou plusieurs mécanismes pour les discussions publiques concernant les changements proposés et les obstacles à l'utilisation.
         details: Établissez un ou plusieurs mécanismes pour des discussions publiques au sein du projet, tels que des listes de diffusion, de la messagerie instantanée ou des systèmes de suivi de problèmes, pour faciliter une communication et des retours ouverts.
       osps_gv_03_01:
-        description: Tant qu'il est actif, la documentation du projet DOIT inclure une explication du processus de contribution.
+        description: La documentation du projet DOIT inclure une explication du processus de contribution, ou indiquer clairement que les contributions publiques ne sont pas acceptées
         details: Créez un fichier CONTRIBUTING.md ou un répertoire CONTRIBUTING/ pour décrire le processus de contribution, y compris les étapes pour soumettre des modifications et interagir avec les mainteneurs du projet.
       osps_le_02_01:
-        description: Tant qu'il est actif, la licence du code source DOIT répondre à la définition de l'Open Source de l'OSI ou à la définition du logiciel libre de la FSF.
+        description: La licence du code source DOIT satisfaire à l'Open Source Definition de l'OSI ou à la Free Software Definition de la FSF.
         details: Ajoutez un fichier LICENSE au dépôt du projet avec une licence qui est une licence approuvée par l'Open Source Initiative (OSI), ou une licence libre approuvée par la Free Software Foundation (FSF). Des exemples de telles licences incluent MIT, BSD 2-clause, BSD 3-clause révisée, Apache 2.0, Lesser GNU General Public License (LGPL) et GNU General Public License (GPL). Publier dans le domaine public répond à ce contrôle s'il n'y a pas d'autres restrictions telles que des brevets.
       osps_le_02_02:
-        description: Tant qu'il est actif, la licence des ressources logicielles publiées DOIT répondre à la définition de l'Open Source de l'OSI ou à la définition du logiciel libre de la FSF.
+        description: La licence des ressources logicielles publiées DOIT satisfaire à l'Open Source Definition de l'OSI ou à la Free Software Definition de la FSF.
         details: Si une licence différente est incluse avec les ressources logicielles publiées, assurez-vous qu'il s'agit d'une licence approuvée par l'Open Source Initiative (OSI), ou d'une licence libre approuvée par la Free Software Foundation (FSF). Des exemples de telles licenses incluent MIT, BSD 2-clause, BSD 3-clause révisée, Apache 2.0, Lesser GNU General Public License (LGPL) et GNU General Public License (GPL). Notez que la licence des ressources logicielles publiées peut être différente de celle du code source.
       osps_le_03_01:
-        description: Tant qu'il est actif, la licence du code source DOIT être maintenue dans le fichier LICENSE, le fichier COPYING ou le répertoire LICENSE/ du dépôt correspondant.
-        details: Incluez la licence du code source du projet dans le fichier LICENSE, le fichier COPYING ou le répertoire LICENSE/ du projet pour fournir visibilité et clarté sur les termes de la licence. Le nom de fichier PEUT avoir une extension. Si le projet a plusieurs dépôts, assurez-vous que chaque dépôt inclut le fichier de licence.
+        description: La licence du code source DOIT être conservée dans le fichier LICENSE, le fichier COPYING, le répertoire LICENSES/ ou le répertoire LICENSE/ du dépôt correspondant.
+        details: Incluez la licence du code source du projet dans le fichier LICENSE, le fichier COPYING, le répertoire LICENSES/ ou le répertoire LICENSE/ du projet afin de fournir de la visibilité et de la clarté sur les conditions de licence. Le nom de fichier PEUT avoir une extension. Si le projet dispose de plusieurs dépôts, assurez-vous que chaque dépôt inclut le fichier de licence.
       osps_le_03_02:
-        description: Tant qu'il est actif, la licence des ressources logicielles publiées DOIT être incluse dans le code source publié, ou dans un fichier LICENSE, un fichier COPYING ou un répertoire LICENSE/ aux côtés des ressources de publication correspondantes.
+        description: La licence des ressources logicielles publiées DOIT être incluse dans le code source publié, ou dans un fichier LICENSE, un fichier COPYING, ou un répertoire LICENSE/ accompagnant les ressources de la version correspondante.
         details: Incluez la licence des ressources logicielles publiées du projet dans le code source publié, ou dans un fichier LICENSE, un fichier COPYING ou un répertoire LICENSE/ aux côtés des ressources de publication correspondantes pour fournir visibilité et clarté sur les termes de la licence. Le nom de fichier PEUT avoir une extension. Si le projet a plusieurs dépôts, assurez-vous que chaque dépôt inclut le fichier de licence.
       osps_qa_01_01:
-        description: Pendant son activité, le référentiel de code source du projet DOIT être publiquement lisible à une URL statique.
+        description: Le dépôt de code source du projet DOIT être lisible publiquement à une URL statique.
         details: Utilisez un VCS commun tel que GitHub, GitLab ou Bitbucket. Assurez-vous que le référentiel est publiquement lisible. Évitez la duplication ou la mise en miroir de référentiels à moins qu'une documentation très visible ne clarifie la source principale. Évitez les changements fréquents du référentiel qui affecteraient l'URL du référentiel. Assurez-vous que le référentiel est public.
       osps_qa_01_02:
         description: Le système de contrôle de version DOIT contenir un enregistrement publiquement lisible de toutes les modifications apportées, qui les a apportées et quand elles ont été apportées.
@@ -165,16 +169,16 @@ fr:
         description: Lorsque le système de gestion de paquets le prend en charge, le référentiel de code source DOIT contenir une liste de dépendances qui tient compte des dépendances directes du langage.
         details: Cela peut prendre la forme d'un fichier de gestionnaire de paquets ou de dépendances de langage qui énumère toutes les dépendances directes telles que package.json, Gemfile ou go.mod.
       osps_qa_04_01:
-        description: Pendant son activité, la documentation du projet DOIT contenir une liste de tous les codes sources qui sont considérés comme des sous-projets.
+        description: Les projets comportant plusieurs dépôts DOIVENT documenter une liste des bases de code qui font partie du projet.
         details: Documentez tous les référentiels de code de sous-projets supplémentaires produits par le projet et compilés dans une version. Cette documentation doit inclure l'état et l'intention du code source respectif.
       osps_qa_05_01:
-        description: Pendant son activité, le système de contrôle de version NE DOIT PAS contenir d'artefacts exécutables générés.
+        description: Le système de contrôle de version NE DOIT PAS contenir d'artefacts exécutables générés.
         details: Supprimez les artefacts exécutables générés dans le système de contrôle de version du projet. Il est recommandé que tout scénario où un artefact exécutable généré apparaît critique pour un processus tel que les tests, il devrait plutôt être généré au moment de la compilation ou stocké séparément et récupéré lors d'une étape de pipeline spécifique bien documentée.
       osps_qa_05_02:
-        description: Pendant son activité, le système de contrôle de version NE DOIT PAS contenir d'artefacts binaires non révisables.
+        description: Le système de contrôle de version NE DOIT PAS contenir d'artefacts binaires non révisables.
         details: N'ajoutez aucun artefact binaire non révisable au système de contrôle de version du projet. Cela inclut les binaires d'applications exécutables, les fichiers de bibliothèque et les artefacts similaires. Cela n'inclut pas les ressources telles que les images graphiques, les fichiers sonores ou musicaux et le contenu similaire généralement stocké dans un format binaire.
       osps_vm_02_01:
-        description: Pendant son activité, la documentation du projet DOIT contenir des contacts de sécurité.
+        description: La documentation du projet DOIT contenir des contacts de sécurité.
         details: Créez un fichier security.md (ou portant un nom similaire) qui contient les contacts de sécurité pour le projet.
       osps_br_01_03:
         description: Lorsqu'un pipeline CI/CD opère sur des instantanés de code non fiables, il DOIT empêcher l'accès aux identifiants et aux ressources privilégiés du CI/CD.
@@ -318,6 +322,11 @@ fr:
     link_invalid_or_used: 'L''activation a échoué. Si votre compte est déjà activé, veuillez vous connecter.
 
       '
+    confirm_heading: Activez votre compte
+    confirm_prompt: 'Cliquez sur le bouton ci-dessous pour confirmer et activer votre compte.
+
+      '
+    confirm_button: Activer mon compte
   detectives:
     github:
       repo_public: Dépôt sur GitHub, qui fournit des dépôts git publics avec des URLs.
@@ -378,3 +387,5 @@ fr:
   pagination:
     first: Première
     last: Dernière
+  sessions:
+    login_failed: Désolé, cette tentative de connexion n'a pas pu être effectuée. Veuillez réessayer.

--- a/config/machine_translations/src_en_fr.yml
+++ b/config/machine_translations/src_en_fr.yml
@@ -105,6 +105,10 @@ en:
       This is an advance notice that your project's "%{old_level}" badge may be
       lost on %{effective_date} when updated criteria take effect.
       Please review your badge entry at the following URL before that date:
+    warned_level_message_no_date: |-
+      This is an advance notice that your project's "%{old_level}" badge may be
+      lost when updated criteria take effect.
+      Please review your badge entry at the following URL:
   criteria:
     baseline-1:
       osps_ac_01_01:
@@ -120,7 +124,7 @@ en:
         description: When an attempt is made to delete the project's primary branch, the version control system MUST treat this as a sensitive activity and require explicit confirmation of intent.
         details: Set branch protection on the primary branch in the project's version control system to prevent deletion.
       osps_br_01_01:
-        description: When a CI/CD pipeline accepts an input parameter, that parameter MUST be sanitized and validated prior to use in the pipeline.
+        description: When a CI/CD pipeline operates on untrusted metadata, those parameters MUST be sanitized and validated prior to use in the pipeline.
         details: CI/CD pipelines should sanitize (quote, escape or exit on expected values) all metadata inputs which correspond to untrusted sources. This includes data such as branch names, commit messages, tags, pull request titles, and author information.
       osps_br_01_02:
         description: When a CI/CD pipeline uses a branch name in its functionality, that name value MUST be sanitized and validated prior to use in the pipeline.
@@ -128,8 +132,8 @@ en:
         description: When the project lists a URI as an official project channel, that URI MUST be exclusively delivered using encrypted channels.
         details: Configure the project's websites and version control systems to use encrypted channels such as SSH or HTTPS for data transmission. Ensure all tools and domains referenced in project documentation can only be accessed via encrypted channels.
       osps_br_03_02:
-        description: When the project lists a URI as an official distribution channel, that URI MUST be exclusively delivered using encrypted channels.
-        details: Configure the project's release pipeline to only fetch data from websites, API responses, and other services which use encrypted channels such as SSH or HTTPS for data transmission.
+        description: When the project lists a URI as an official distribution channel, that channel MUST be protected from adversary-in-the-middle attacks using cryptographically authenticated channels.
+        details: Artifacts distributed by the project should be distributed through channels which ensure integrity and authenticity. Use of HTTPS for downloads, signed releases, or distribution through trusted package managers are all acceptable methods to protect against adversary-in-the-middle attacks.
       osps_br_07_01:
         description: The project MUST prevent the unintentional storage of unencrypted sensitive data, such as secrets and credentials, in the version control system.
         details: Configure .gitignore or equivalent to exclude files that may contain sensitive information. Use pre-commit hooks and automated scanning tools to detect and prevent the inclusion of sensitive data in commits.
@@ -140,25 +144,25 @@ en:
         description: When the project has made a release, the project documentation MUST include a guide for reporting defects.
         details: It is recommended that projects use their VCS default issue tracker. If an external source is used, ensure that the project documentation and contributing guide clearly and visibly explain how to use the reporting system. It is recommended that project documentation also sets expectations for how defects will be triaged and resolved.
       osps_gv_02_01:
-        description: While active, the project MUST have one or more mechanisms for public discussions about proposed changes and usage obstacles.
+        description: The project MUST have one or more mechanisms for public discussions about proposed changes and usage obstacles.
         details: Establish one or more mechanisms for public discussions within the project, such as mailing lists, instant messaging, or issue trackers, to facilitate open communication and feedback.
       osps_gv_03_01:
-        description: While active, the project documentation MUST include an explanation of the contribution process.
+        description: The project documentation MUST include an explanation of the contribution process, or clearly state that public contributions are not accepted
         details: Create a CONTRIBUTING.md or CONTRIBUTING/ directory to outline the contribution process including the steps for submitting changes, and engaging with the project maintainers.
       osps_le_02_01:
-        description: While active, the license for the source code MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
+        description: The license for the source code MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
         details: Add a LICENSE file to the project's repo with a license that is an approved license by the Open Source Initiative (OSI), or a free license as approved by the Free Software Foundation (FSF). Examples of such licenses include the MIT, BSD 2-clause, BSD 3-clause revised, Apache 2.0, Lesser GNU General Public License (LGPL), and the GNU General Public License (GPL). Releasing to the public domain meets this control if there are no other encumbrances such as patents.
       osps_le_02_02:
-        description: While active, the license for the released software assets MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
+        description: The license for the released software assets MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
         details: If a different license is included with released software assets, ensure it is an approved license by the Open Source Initiative (OSI), or a free license as approved by the Free Software Foundation (FSF). Examples of such licenses include the MIT, BSD 2-clause, BSD 3-clause revised, Apache 2.0, Lesser GNU General Public License (LGPL), and the GNU General Public License (GPL). Note that the license for the released software assets may be different than the source code.
       osps_le_03_01:
-        description: While active, the license for the source code MUST be maintained in the corresponding repository's LICENSE file, COPYING file, or LICENSE/ directory.
-        details: Include the project's source code license in the project's LICENSE file, COPYING file, or LICENSE/ directory to provide visibility and clarity on the licensing terms. The filename MAY have an extension. If the project has multiple repositories, ensure that each repository includes the license file.
+        description: The license for the source code MUST be maintained in the corresponding repository's LICENSE file, COPYING file, LICENSES/ directory, or LICENSE/ directory.
+        details: Include the project's source code license in the project's LICENSE file, COPYING file, LICENSES/ directory, or LICENSE/ directory to provide visibility and clarity on the licensing terms. The filename MAY have an extension. If the project has multiple repositories, ensure that each repository includes the license file.
       osps_le_03_02:
-        description: While active, the license for the released software assets MUST be included in the released source code, or in a LICENSE file, COPYING file, or LICENSE/ directory alongside the corresponding release assets.
+        description: The license for the released software assets MUST be included in the released source code, or in a LICENSE file, COPYING file, or LICENSE/ directory alongside the corresponding release assets.
         details: Include the project's released software assets license in the released source code, or in a LICENSE file, COPYING file, or LICENSE/ directory alongside the corresponding release assets to provide visibility and clarity on the licensing terms. The filename MAY have an extension. If the project has multiple repositories, ensure that each repository includes the license file.
       osps_qa_01_01:
-        description: While active, the project's source code repository MUST be publicly readable at a static URL.
+        description: The project's source code repository MUST be publicly readable at a static URL.
         details: Use a common VCS such as GitHub, GitLab, or Bitbucket. Ensure the repository is publicly readable. Avoid duplication or mirroring of repositories unless highly visible documentation clarifies the primary source. Avoid frequent changes to the repository that would impact the repository URL. Ensure the repository is public.
       osps_qa_01_02:
         description: The version control system MUST contain a publicly readable record of all changes made, who made the changes, and when the changes were made.
@@ -167,16 +171,16 @@ en:
         description: When the package management system supports it, the source code repository MUST contain a dependency list that accounts for the direct language dependencies.
         details: This may take the form of a package manager or language dependency file that enumerates all direct dependencies such as package.json, Gemfile, or go.mod.
       osps_qa_04_01:
-        description: While active, the project documentation MUST contain a list of any codebases that are considered subprojects.
+        description: Projects with multiple repositories MUST document a list of codebases that are part of the project.
         details: Document any additional subproject code repositories produced by the project and compiled into a release. This documentation should include the status and intent of the respective codebase.
       osps_qa_05_01:
-        description: While active, the version control system MUST NOT contain generated executable artifacts.
+        description: The version control system MUST NOT contain generated executable artifacts.
         details: Remove generated executable artifacts in the project's version control system. It is recommended that any scenario where a generated executable artifact appears critical to a process such as testing, it should be instead be generated at build time or stored separately and fetched during a specific well-documented pipeline step.
       osps_qa_05_02:
-        description: While active, the version control system MUST NOT contain unreviewable binary artifacts.
+        description: The version control system MUST NOT contain unreviewable binary artifacts.
         details: Do not add any unreviewable binary artifacts to the project's version control system. This includes executable application binaries, library files, and similar artifacts. It does not include assets such as graphical images, sound or music files, and similar content typically stored in a binary format.
       osps_vm_02_01:
-        description: While active, the project documentation MUST contain security contacts.
+        description: The project documentation MUST contain security contacts.
         details: Create a security.md (or similarly-named) file that contains security contacts for the project.
       osps_br_01_03:
         description: When a CI/CD pipeline operates on untrusted code snapshots, it MUST prevent access to privileged CI/CD credentials and assets.
@@ -322,6 +326,11 @@ en:
     link_invalid_or_used: 'Activation failed. If your account is already activated, please log in.
 
       '
+    confirm_heading: Activate Your Account
+    confirm_prompt: 'Click the button below to confirm and activate your account.
+
+      '
+    confirm_button: Activate my account
   detectives:
     github:
       repo_public: Repository on GitHub, which provides public git repositories with URLs.
@@ -382,3 +391,5 @@ en:
   pagination:
     first: First
     last: Last
+  sessions:
+    login_failed: Sorry, that login attempt could not be completed. Please try again.


### PR DESCRIPTION
rake translation:ai[fr,20], the first real batch run since fixing stale- translation detection. Retranslates 20 of the 36 keys that fix now correctly flags: the "While active,"/"Pendant son activité," prefix drops everywhere the English dropped it, osps_le_03_01 picks up the new LICENSES/ directory wording, and osps_br_01_01/osps_br_03_02 turn out to have been even more stale than the recent baseline update alone would explain - previously invisible for the same reason, now caught and fixed.

Verified the term-extraction/example-selection mechanism itself worked as designed: all 30 example slots for this batch were genuinely term-driven, matched across the whole corpus (baseline criteria sharing vocabulary with older passing/silver-level criteria), and terminology stayed consistent with an existing human translation without copying its typo.

16 keys remain for a follow-up batch.


Claude-Session: https://claude.ai/code/session_01DijGYkCYuM4MBrKanansoX
Assisted-by: Claude:claude-sonnet-5