### PR TITLE
Split translation:status's Machine count into Current vs. Outdated

### DIFF
--- a/lib/tasks/machine_translation_helpers.rb
+++ b/lib/tasks/machine_translation_helpers.rb
@@ -116,6 +116,15 @@ module MachineTranslationHelpers
       !human_translations[key].to_s.strip.empty?
     end
 
+    # Whether the existing machine translation for `key` is outdated: one
+    # exists, but English changed since it was generated (tracked via
+    # src_en_LOCALE.yml). Human translations are never checked for
+    # staleness here by design (see human_translation_present?) - only
+    # machine translations get this source-tracking file at all.
+    def machine_translation_outdated?(source_tracking, key, english_value)
+      source_tracking.key?(key) && source_tracking[key] != english_value
+    end
+
     def find_untranslated_keys(locale)
       english = load_flat_translations('en')
       translated = load_flat_translations(locale)
@@ -138,8 +147,7 @@ module MachineTranslationHelpers
         next true if value.nil? || value.to_s.strip.empty?
         next false if human_translation_present?(human_translated, key) # ignore source changes
 
-        # Check if English source has changed since machine translation
-        source_tracking.key?(key) && source_tracking[key] != english_value
+        machine_translation_outdated?(source_tracking, key, english_value)
       end
     end
 
@@ -370,7 +378,7 @@ module MachineTranslationHelpers
       # Collect per-locale stats first, then display in two passes
       locale_stats =
         TRANSLATION_PRIORITY.map do |locale|
-          compute_locale_status(locale, translatable_keys)
+          compute_locale_status(locale, translatable_keys, english)
         end
 
       # Pass 1: summary table
@@ -378,9 +386,11 @@ module MachineTranslationHelpers
       puts '-' * 60
       locale_stats.each do |stats|
         puts format(
-          '%-8<loc>s Human: %4<human>d  Machine: %4<machine>d  Missing: %4<miss>d',
+          '%-5<loc>s  Human: %4<human>d  AI-Current: %4<mc>d  ' \
+          'AI-Outdated: %4<mo>d  Missing: %4<miss>d',
           loc: stats[:locale], human: stats[:human_count],
-          machine: stats[:machine_only_count], miss: stats[:missing_keys].length
+          mc: stats[:machine_current_count], mo: stats[:machine_outdated_count],
+          miss: stats[:missing_keys].length
         )
       end
 
@@ -781,21 +791,29 @@ module MachineTranslationHelpers
 
     private
 
-    # Partition translatable keys into human, machine-only, and missing.
-    # Returns a hash with counts and the list of missing keys.
-    def compute_locale_status(locale, translatable_keys)
+    # Partition translatable keys into human, machine-current,
+    # machine-outdated, and missing - four mutually-exclusive, exhaustive
+    # buckets that sum to translatable_keys.length. Returns a hash with
+    # counts and the list of missing keys.
+    def compute_locale_status(locale, translatable_keys, english)
       human = load_flat_translations(locale, human_only: true)
       machine = load_flat_translations(locale, machine_only: true)
+      source_tracking = load_source_tracking(locale)
 
       human_count = 0
-      machine_only_count = 0
+      machine_current_count = 0
+      machine_outdated_count = 0
       missing_keys = []
 
       translatable_keys.each do |key|
         if non_empty_value?(human[key])
           human_count += 1
         elsif non_empty_value?(machine[key])
-          machine_only_count += 1
+          if machine_translation_outdated?(source_tracking, key, english[key])
+            machine_outdated_count += 1
+          else
+            machine_current_count += 1
+          end
         else
           missing_keys << key
         end
@@ -803,7 +821,8 @@ module MachineTranslationHelpers
 
       {
         locale: locale, human_count: human_count,
-        machine_only_count: machine_only_count, missing_keys: missing_keys
+        machine_current_count: machine_current_count,
+        machine_outdated_count: machine_outdated_count, missing_keys: missing_keys
       }
     end
 

--- a/test/lib/tasks/machine_translation_helpers_test.rb
+++ b/test/lib/tasks/machine_translation_helpers_test.rb
@@ -180,5 +180,23 @@ class MachineTranslationHelpersTest < ActiveSupport::TestCase
     assert MachineTranslationHelpers.human_translation_present?(human_translations, 'sessions.signed_in')
     assert_not MachineTranslationHelpers.human_translation_present?(human_translations, 'no_such_key')
   end
+
+  test 'machine_translation_outdated? is true when the tracked source differs from current English' do
+    source_tracking = { 'osps_gv_02_01.description' => 'While active, the project MUST...' }
+    assert MachineTranslationHelpers.machine_translation_outdated?(
+      source_tracking, 'osps_gv_02_01.description', 'The project MUST...'
+    )
+  end
+
+  test 'machine_translation_outdated? is false when the tracked source still matches' do
+    source_tracking = { 'pagination.first' => 'First' }
+    assert_not MachineTranslationHelpers.machine_translation_outdated?(
+      source_tracking, 'pagination.first', 'First'
+    )
+  end
+
+  test 'machine_translation_outdated? is false when there is no tracked source at all' do
+    assert_not MachineTranslationHelpers.machine_translation_outdated?({}, 'some.key', 'Some text')
+  end
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
The status line reported one "Machine: N" count meaning "has some machine translation," with no way to tell a current one from a stale one. That's misleading on its own terms: rake translation:ai already retranslates outdated machine translations, not just missing ones, so the status line didn't reflect what a real batch run would do. We saw this directly - translation:status told us French was missing only 5 keys right after the baseline reword, when the real count needing retranslation (per find_untranslated_keys) was 36.

Now each locale reports four mutually-exclusive, exhaustive buckets - Human, AI-Current, AI-Outdated, Missing - that sum to the locale's translatable-key count. Extracted the staleness check find_untranslated_keys already had into a shared
machine_translation_outdated? predicate so both functions agree on what "outdated" means, instead of drifting apart. Also matches the same present-vs-exists discipline as human_translation_present? (commit 85e775ed): compute_locale_status already checked values via non_empty_value?, not mere key presence, so this only had to extend that same care to the new outdated check.

Verified against the real corpus: for French, 733 + 228 + 31 + 5 = 997 (the full translatable-key count), and AI-Outdated + Missing (31 + 5 = 36) matches translation:untranslated[fr] exactly.

Tightened the status line to fit 80 columns: narrower locale column (5 chars, enough for "zh-CN") and shorter "AI-Current"/"AI-Outdated" labels instead of "Machine Current"/"Machine Outdated".


Claude-Session: https://claude.ai/code/session_01DijGYkCYuM4MBrKanansoX
Assisted-by: Claude:claude-sonnet-5