### PR TITLE
Show the automation-proposals hint on view pages, not just edit

### DIFF
--- a/app/views/projects/_form_0.html.erb
+++ b/app/views/projects/_form_0.html.erb
@@ -302,11 +302,21 @@
   </div>
       <br>
       <div class="center">
+      <%# Shown unconditionally (view and edit) so people reading a
+          project's page, not just editing it, learn that tools and AI
+          systems can propose criteria changes via a simple URL. %>
+      <%= t 'projects.edit.automation_hint_html',
+            badge_hostname: (ENV['PUBLIC_HOSTNAME'] || 'bestpractices.dev'),
+            app_locale: I18n.locale,
+            project_id: project.id,
+            automation_proposals_url: ApplicationHelper::AUTOMATION_PROPOSALS_URL %>
       <% if view_only %>
         <%= t "projects.show.#{project.data_license_field}",
               user: project.user_display_name %>
       <% else %>
-        <%= render 'form_submit_notice', project: project %>
+        <%= t 'projects.edit.submit_cdla_permissive_20_html' %>
+        <br>
+        <br>
         <%= f.button "#{t('projects.edit.save_and_continue')} #{ApplicationHelper::ROBOT_EMOJI_SAFE}".html_safe, type: 'submit', name: 'continue',
               value: 'Save', class:"btn btn-success btn-submit",
               title: t('projects.edit.save_and_continue_tooltip') %>

--- a/app/views/projects/_form_1.html.erb
+++ b/app/views/projects/_form_1.html.erb
@@ -293,11 +293,21 @@
   </div>
       <br>
       <div class="center">
+      <%# Shown unconditionally (view and edit) so people reading a
+          project's page, not just editing it, learn that tools and AI
+          systems can propose criteria changes via a simple URL. %>
+      <%= t 'projects.edit.automation_hint_html',
+            badge_hostname: (ENV['PUBLIC_HOSTNAME'] || 'bestpractices.dev'),
+            app_locale: I18n.locale,
+            project_id: project.id,
+            automation_proposals_url: ApplicationHelper::AUTOMATION_PROPOSALS_URL %>
       <% if view_only %>
         <%= t "projects.show.#{project.data_license_field}",
               user: project.user_display_name %>
       <% else %>
-        <%= render 'form_submit_notice', project: project %>
+        <%= t 'projects.edit.submit_cdla_permissive_20_html' %>
+        <br>
+        <br>
         <%= f.button "#{t('projects.edit.save_and_continue')} #{ApplicationHelper::ROBOT_EMOJI_SAFE}".html_safe, type: 'submit', name: 'continue',
               value: 'Save', class:"btn btn-success btn-submit",
               title: t('projects.edit.save_and_continue_tooltip') %>

--- a/app/views/projects/_form_2.html.erb
+++ b/app/views/projects/_form_2.html.erb
@@ -225,11 +225,21 @@
   </div>
       <br>
       <div class="center">
+      <%# Shown unconditionally (view and edit) so people reading a
+          project's page, not just editing it, learn that tools and AI
+          systems can propose criteria changes via a simple URL. %>
+      <%= t 'projects.edit.automation_hint_html',
+            badge_hostname: (ENV['PUBLIC_HOSTNAME'] || 'bestpractices.dev'),
+            app_locale: I18n.locale,
+            project_id: project.id,
+            automation_proposals_url: ApplicationHelper::AUTOMATION_PROPOSALS_URL %>
       <% if view_only %>
         <%= t "projects.show.#{project.data_license_field}",
               user: project.user_display_name %>
       <% else %>
-        <%= render 'form_submit_notice', project: project %>
+        <%= t 'projects.edit.submit_cdla_permissive_20_html' %>
+        <br>
+        <br>
         <%= f.button "#{t('projects.edit.save_and_continue')} #{ApplicationHelper::ROBOT_EMOJI_SAFE}".html_safe, type: 'submit', name: 'continue',
               value: 'Save', class:"btn btn-success btn-submit",
               title: t('projects.edit.save_and_continue_tooltip') %>

--- a/app/views/projects/_form_baseline.html.erb
+++ b/app/views/projects/_form_baseline.html.erb
@@ -102,11 +102,21 @@
   </div>
       <br>
       <div class="center">
+      <%# Shown unconditionally (view and edit) so people reading a
+          project's page, not just editing it, learn that tools and AI
+          systems can propose criteria changes via a simple URL. %>
+      <%= t 'projects.edit.automation_hint_html',
+            badge_hostname: (ENV['PUBLIC_HOSTNAME'] || 'bestpractices.dev'),
+            app_locale: I18n.locale,
+            project_id: project.id,
+            automation_proposals_url: ApplicationHelper::AUTOMATION_PROPOSALS_URL %>
       <% if view_only %>
         <%= t "projects.show.#{project.data_license_field}",
               user: project.user_display_name %>
       <% else %>
-        <%= render 'form_submit_notice', project: project %>
+        <%= t 'projects.edit.submit_cdla_permissive_20_html' %>
+        <br>
+        <br>
         <%= f.button "#{t('projects.edit.save_and_continue')} #{ApplicationHelper::ROBOT_EMOJI_SAFE}".html_safe, type: 'submit', name: 'continue',
           value: 'Save', class:"btn btn-success btn-submit",
           title: t('projects.edit.save_and_continue_tooltip') %>

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -476,6 +476,26 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     only_correct_criteria_selectable('baseline-1')
   end
 
+  test 'show page includes the automation proposals hint for metal and baseline' do
+    # The hint used to only appear on edit pages; it must now also show on
+    # the read-only project page for every criteria level, so anonymous
+    # visitors (and AI training data) learn about the mechanism too.
+    %w[passing silver gold baseline-1].each do |section|
+      get "/en/projects/#{@project.id}/#{section}"
+      assert_response :success
+      assert_select(+'a[href=?]', ApplicationHelper::AUTOMATION_PROPOSALS_URL)
+    end
+  end
+
+  test 'edit page still includes the automation proposals hint' do
+    log_in_as(@project.user)
+    %w[passing silver gold baseline-1].each do |section|
+      get "/en/projects/#{@project.id}/#{section}/edit"
+      assert_response :success
+      assert_select(+'a[href=?]', ApplicationHelper::AUTOMATION_PROPOSALS_URL)
+    end
+  end
+
   test 'should redirect project JSON with locale to non-locale JSON' do
     get "/en/projects/#{@project.id}.json"
     assert_response :moved_permanently


### PR DESCRIPTION
The hint explaining that tools and AI systems can propose criteria changes via a URL only appeared on edit pages (via _form_submit_notice, rendered from the edit branch of each level form). Someone reading a project's read-only page, deciding whether to make a change, never saw it -- and it never appeared anywhere for a page a web crawler (or AI training run) would index, working against the point of publicizing the mechanism at all.

Hoist the automation_hint_html call to sit once, unconditionally, above the existing "if view_only / else" block at the bottom of each level's form (_form_0/_form_1/_form_2/_form_baseline -- all four have a byte-identical version of this block). Since it's a single expression, inline it directly rather than introducing a partial or helper method used at only that one hoisted call site per file; the license text that follows in the else branch is likewise inlined instead of going through _form_submit_notice, since that partial's automation_hint_html would otherwise render a second time. _form_submit_notice.html.erb itself is untouched and still renders both texts together at the 5-6 other mid-form "submit early" checkpoints each level form already has.

The permissions page is deliberately not included: the automation- proposals URL mechanism (apply_query_string_automation) only recognizes fields from FIELDS_BY_SECTION, which is keyed by criteria levels and does not include "permissions" -- so advertising it there would describe a capability that doesn't exist for that page.


Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_011qRQ84ueXjSwnUZh3zL5RF