### PR TITLE
Move bundle_audit off the default/CI gate; file a tracking issue instead

### DIFF
--- a/.github/workflows/bundle_audit.yml
+++ b/.github/workflows/bundle_audit.yml
@@ -1,0 +1,173 @@
+# Copyright the Linux Foundation and the OpenSSF Best Practices badge contributors
+# SPDX-License-Identifier: MIT
+
+name: Bundle audit
+
+# Check Gemfile.lock against the ruby-advisory-db for known vulnerabilities,
+# and track the result as a GitHub issue instead of a build status.
+#
+# THIS USED TO GATE THE BUILD. "rake bundle_audit" was part of
+# DYNAMIC_CHECKS in lib/tasks/default.rake, so it ran, and could fail,
+# on every pull request and every deploy. That is the wrong shape for
+# what it checks: the advisory database moves independently of our
+# commits, so a gem set that was clean when a pull request opened can
+# fail this check days later for a reason that pull request never
+# touched, and the same is true of an unrelated deploy. A notification
+# does not need to hold up work that has nothing to do with it. See
+# lib/tasks/default.rake for the reasoning that used to justify gating.
+# This workflow does not call "rake bundle_audit" itself; see below.
+#
+# ONE OPEN ISSUE AT A TIME, updated in place while the problem stands and
+# closed automatically once a run comes back clean, the same "don't let
+# a reminder become noise" reasoning as
+# .github/workflows/dependabot_review.yml. That one only ever files,
+# because an expired review date does not un-expire on its own; a
+# vulnerability finding can resolve itself (a later gem bump, or an
+# entry added to .bundler-audit.yml), so this one also closes.
+#
+# NO FULL "bundle install", so no "rake bundle_audit" either: that task
+# runs through "bundle exec", which needs the whole app bundle installed
+# via Bundler.setup, not just the bundler-audit gem. "pg" alone would
+# need libpq-dev on the runner to compile, for a check that only reads
+# Gemfile.lock and never touches an installed gem. Running bundle-audit
+# standalone instead, the way .github/workflows/brakeman.yml runs
+# Brakeman, skips all of that. Unlike Brakeman, though, bundler-audit IS
+# in our Gemfile (for "rake bundle_audit" locally), so this workflow
+# reads Gemfile.lock for which version to install rather than pinning
+# its own, which would be a second copy of that version free to drift
+# from the first.
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # Daily: a new advisory can land any day, and the whole point of
+    # this check is to notice promptly rather than wait for the next
+    # pull request. Minute and hour chosen to miss every other
+    # scheduled job's slot; see .github/dependabot.yml for the list.
+    - cron: '17 7 * * *'
+  # So a human can ask without waiting for the schedule.
+  workflow_dispatch:
+
+jobs:
+  audit:
+    name: Check Gemfile.lock for known vulnerabilities
+    runs-on: ubuntu-latest
+
+    steps:
+      # Use harden-runner https://github.com/step-security/harden-runner
+      # presented at OpenSSF Best Practices WG 2022-03-15
+      - uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        # Pin to commit SHA to prevent supply chain attacks via tag mutation.
+        # Verify: curl -s https://api.github.com/repos/actions/checkout/git/ref/tags/v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job never pushes; nothing here should be able to.
+          persist-credentials: false
+
+      # OSPS-BR-01.02: Validate branch name before use in pipeline
+      - name: Validate branch name
+        run: script/validate_branch_name "$GITHUB_REF_NAME"
+
+      # Read the version bundler-audit resolves to in Gemfile.lock, so this
+      # workflow always installs the same version "rake bundle_audit" would
+      # use locally, kept current automatically by whatever bumps the
+      # Gemfile (Dependabot included) rather than by someone remembering to
+      # edit this file too.
+      - name: Read the bundler-audit version Gemfile.lock pins
+        id: version
+        run: |
+          set -euo pipefail
+          version="$(sed -n 's/^    bundler-audit (\([0-9.]*\)).*/\1/p' Gemfile.lock)"
+          if [ -z "$version" ]; then
+            echo '::error::bundler-audit not found in Gemfile.lock' >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install bundler-audit (standalone; no app bundle needed)
+        run: |
+          sudo gem install bundler-audit \
+            --version "${{ steps.version.outputs.version }}" --no-document
+
+      # bundle-audit reads .bundler-audit.yml from the working directory
+      # automatically, so accepted findings recorded there (with rationale)
+      # are already filtered out here, the same as in "rake bundle_audit".
+      - name: Check Gemfile.lock for known vulnerabilities
+        id: audit
+        run: |
+          set +e
+          output="$(bundle-audit check --update 2>&1)"
+          status=$?
+          set -e
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          {
+            echo 'report<<REPORT_EOF'
+            echo "$output"
+            echo 'REPORT_EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "$output"
+
+      - name: Mint a short-lived token from the App
+        id: app_token
+        uses: ./.github/actions/mint-app-token
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+          # Reading the open issues, and filing, editing, or closing one,
+          # is all this needs.
+          permission-issues: write
+
+      - name: File, update, or close the tracking issue
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          REPO: ${{ github.repository }}
+          STATUS: ${{ steps.audit.outputs.status }}
+          REPORT: ${{ steps.audit.outputs.report }}
+          TITLE: bundle-audit found a known vulnerability
+        run: |
+          set -euo pipefail
+
+          # --limit 100: "gh issue list" defaults to 30, and this repo can
+          # have more than 30 open issues at once. Missing an
+          # already-open tracking issue here would defeat the ONE OPEN
+          # ISSUE AT A TIME invariant below by filing a duplicate.
+          issue_number="$(
+            gh issue list --repo "$REPO" --state open --limit 100 \
+              --json number,title |
+              jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' |
+              head -n1
+          )"
+
+          if [ "$STATUS" != '0' ]; then
+            body="$(cat <<BODY_EOF
+          $REPORT
+
+          Raised by .github/workflows/bundle_audit.yml, on a daily schedule,
+          not by a pull request. If this isn't exploitable in how we use the
+          gem, record it with rationale in .bundler-audit.yml rather than
+          closing this issue by hand: the next scheduled run closes it once
+          the check agrees.
+          BODY_EOF
+            )"
+            if [ -n "$issue_number" ]; then
+              gh issue edit "$issue_number" --repo "$REPO" --body "$body"
+              echo "Updated issue #$issue_number."
+            else
+              gh issue create --repo "$REPO" --title "$TITLE" --body "$body" \
+                --label dependencies
+              echo 'Issue filed.'
+            fi
+          elif [ -n "$issue_number" ]; then
+            gh issue comment "$issue_number" --repo "$REPO" \
+              --body 'bundle-audit is clean again; closing.'
+            gh issue close "$issue_number" --repo "$REPO"
+            echo "Closed issue #$issue_number."
+          else
+            echo 'Clean; nothing open to close.'
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -586,8 +586,6 @@ check the software:
 *   *bundle* - use bundle to check dependencies
     ("bundle check || bundle install")
 *   *bundle_doctor* - sanity check on Ruby gem configuration/installation
-*   *bundle_audit* - check for transitive gem dependencies with
-    known vulnerabilities
 *   *rubocop* - runs Rubocop, which checks Ruby code style against the
     [community Ruby style guide](https://github.com/bbatsov/ruby-style-guide)
 *   *markdownlint* - runs markdownlint, also known as mdl
@@ -876,12 +874,15 @@ over the exact versions used for each gem, and we
 can easily update our dependencies.
 That's important, because we transitively depend on over 150 gems.
 
-The default 'rake' task and the variant used by our
-continuous integration (CI) suite includes the rake 'bundle_audit' task.
-This reports if a Ruby gem we use has a publicly known
-vulnerability listed in the National Vulnerability Database (NVD).
-Thus, simply running 'rake' will immediately warn you if there is a
-publicly known vulnerability in the version of a gem we use.
+The rake 'bundle_audit' task reports if a Ruby gem we use has a publicly
+known vulnerability listed in the National Vulnerability Database (NVD).
+Run it directly with 'rake bundle_audit' for a manual, local check.
+It no longer runs as part of the default 'rake' task or the CI suite,
+because the vulnerability database it reads moves independently of our
+commits, so a failure there is unrelated to whatever a given commit or
+pull request changed. Instead, `.github/workflows/bundle_audit.yml` runs
+it on a daily schedule and files or updates a GitHub issue when it finds
+something.
 Obviously, if there is a known vulnerability you *definitely* need
 to update that gem.
 

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -102,12 +102,19 @@ STATIC_CHECKS = %w[
   report_code_statistics
 ].freeze
 
-# DYNAMIC: not settled by the commit. bundle_audit reads an advisory
-# database and percent_gems_up_to_date reads rubygems.org, both of which
-# move underneath an unchanged commit, so a gem set that was clean when
-# it merged can be vulnerable by the time it deploys. That is exactly
-# the moment we want to be told, so these run on every build, deploys
-# included.
+# DYNAMIC: not settled by the commit. percent_gems_up_to_date reads
+# rubygems.org, which moves underneath an unchanged commit, so it is a
+# fact about now rather than about the code. That is exactly the moment
+# we want to be told, so it runs on every build, deploys included.
+#
+# bundle_audit used to be here for the same reason: it also reads
+# something (an advisory database) that moves independently of the
+# commit. But that meant a newly disclosed vulnerability, unrelated to
+# whatever a pull request actually changed, could fail that pull
+# request's build, or an unrelated deploy. It now runs on its own daily
+# schedule instead, in .github/workflows/bundle_audit.yml, which files
+# or updates a GitHub issue rather than failing a build. "rake
+# bundle_audit" below still works for a manual, local check.
 #
 # The tests belong here for the same reason rather than by analogy: a
 # green suite is not a property of the commit alone. Re-running it is
@@ -117,7 +124,6 @@ STATIC_CHECKS = %w[
 # test:optimized runs the regular tests (parallelized) and then the
 # system tests (serial).
 DYNAMIC_CHECKS = %w[
-  bundle_audit
   percent_gems_up_to_date
   ruby_version_deployable
   test:optimized
@@ -945,7 +951,10 @@ end
 #
 # DYNAMIC, not static: Heroku can withdraw a Ruby under an unchanged
 # tree, and the moment to hear about that is the deploy we were about
-# to do. Same argument as bundle_audit.
+# to do. Same argument as percent_gems_up_to_date: this one still gates
+# the build, though, rather than filing an issue like bundle_audit now
+# does, because an undeployable Ruby is not a risk to weigh, it is a
+# deploy that will not happen.
 #
 # NOT A MINITEST TEST. test/test_helper.rb disables outbound
 # connections, and WebMock's refusal is not a network error, so any


### PR DESCRIPTION
bundle_audit was part of DYNAMIC_CHECKS, so it ran, and could fail, on every pull request and every deploy via CircleCI's dynamic_checks job. That's the wrong shape: the advisory database it reads moves independently of our commits, so a gem set clean when a PR opened can fail this check days later for a reason that PR never touched, and the same is true of an unrelated deploy.

Add .github/workflows/bundle_audit.yml, following the same pattern already used for license_finder (#3004) and Brakeman: install bundler-audit standalone (reading the version Gemfile.lock pins, so it can't drift from what "rake bundle_audit" uses locally) rather than doing a full "bundle install" just to check a lockfile. It runs daily, and files, updates, or closes a single tracking GitHub issue rather than failing a build, the same "one open issue, not a new one per run" approach as dependabot_review.yml.

Remove bundle_audit from DYNAMIC_CHECKS and update the comments that explained why it was there. Fix CONTRIBUTING.md's two references to it running as part of the default/CI rake task.

Assisted-by: Claude:claude-sonnet-5

Claude-Session: https://claude.ai/code/session_0174ddfmVbMR5k752Kd2CdHS