### PR TITLE
Bump rubocop-rails to 2.37.0; fix/disable new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -153,6 +153,18 @@ Style/MixinUsage:
   Enabled: false
 Rails/EnvironmentComparison:
   Enabled: false
+# Most flagged sites are initializers/rake tasks gating third-party setup
+# by deployment environment (config/initializers/*, lib/tasks/default.rake);
+# moving that into "config or a feature flag" as the cop suggests would
+# just relocate the same Rails.env coupling one file over, since an
+# environment-specific config file is itself environment-dependent. The
+# app/models/user.rb cases the cop's testability rationale actually targets
+# already solve that problem: email_encryption_key_hex/email_blind_index_key_hex
+# take an env_test: keyword specifically so tests can exercise the
+# production branch without touching RAILS_ENV, which is the dependency
+# injection the cop wants, just not via Rails config.
+Rails/Env:
+  Enabled: false
 Lint/MissingCopEnableDirective:
   Enabled: false
 Lint/NumberConversion:

--- a/Gemfile
+++ b/Gemfile
@@ -189,7 +189,7 @@ group :development, :test do
   # gem 'railroader', '4.3.8' # Security static analyzer. OSS fork of Brakeman
   gem 'rubocop', '1.89.0', require: false # Style checker
   gem 'rubocop-performance', '~> 1.20', require: false # Performance cops
-  gem 'rubocop-rails', '2.33.4', require: false # Rails-specific cops
+  gem 'rubocop-rails', '2.37.0', require: false # Rails-specific cops
   gem 'ruby-graphviz', '1.2.5' # This is used for bundle viz
   # Spring, a preloader that keeps the application resident so repeated
   # commands start instantly. Commented out 2026-08-05 rather than

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,11 +488,11 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.33.4)
+    rubocop-rails (2.37.0)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
-      rubocop (>= 1.75.0, < 2.0)
+      rubocop (>= 1.89.0, < 2.0)
       rubocop-ast (>= 1.44.0, < 2.0)
     ruby-graphviz (1.2.5)
       rexml
@@ -668,7 +668,7 @@ DEPENDENCIES
   redcarpet!
   rubocop (= 1.89.0)
   rubocop-performance (~> 1.20)
-  rubocop-rails (= 2.33.4)
+  rubocop-rails (= 2.37.0)
   ruby-graphviz (= 1.2.5)
   sassc-rails
   scout_apm
@@ -885,7 +885,7 @@ CHECKSUMS
   rubocop (1.89.0) sha256=4dee8e3ee9c45e474834efd9e8d6fd031e8331c8dacdff0de4ad65ae0a6faae7
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
-  rubocop-rails (2.33.4) sha256=34ec8f6637706dc224483d949ccc88b3e41596a81a11a1ec0c7d74ecbea356b5
+  rubocop-rails (2.37.0) sha256=6e1645add5060e0328f8ddda0d820f55697c591394398bf14bb9dccb62f14b7e
   ruby-graphviz (1.2.5) sha256=1c2bb44e3f6da9e2b829f5e7fd8d75a521485fb6b4d1fc66ff0f93f906121504
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   rubyzip (3.6.0) sha256=268994d44d62282d1cfd99bf10eae48d7267199158ad7ea3e1fee2da9458b695

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -541,7 +541,7 @@ class ProjectsController < ApplicationController
     # important because this common request is supposed to be quick.
     # Note: If the "find" fails this will raise an exception, which
     # will eventually lead (correctly) to a failure report.
-    @project = Project.select(BADGE_PROJECT_FIELDS).find(params[:id])
+    @project = Project.select(BADGE_PROJECT_FIELDS).find(params.expect(:id))
 
     respond_to do |format|
       format.svg do
@@ -571,7 +571,7 @@ class ProjectsController < ApplicationController
   # rubocop:disable Metrics/MethodLength
   def baseline_badge
     # Select only the fields we need for performance
-    @project = Project.select(BASELINE_BADGE_PROJECT_FIELDS).find(params[:id])
+    @project = Project.select(BASELINE_BADGE_PROJECT_FIELDS).find(params.expect(:id))
 
     respond_to do |format|
       format.svg do
@@ -1370,7 +1370,7 @@ class ProjectsController < ApplicationController
     # This will NOT match full URLs, but will match partial URLs.
     @projects = @projects.search_for(params[:q]) if params[:q].present?
     if params[:ids].present?
-      @projects = @projects.where(id: params[:ids].split(',').map do |x|
+      @projects = @projects.where(id: params.expect(:ids).split(',').map do |x|
                                         Integer(x)
                                       end)
     end
@@ -1440,12 +1440,12 @@ class ProjectsController < ApplicationController
   # Used as before_action to set @project for actions that need it.
   # @return [void] Sets @project instance variable
   def set_project_all_values
-    @project = Project.find(params[:id])
+    @project = Project.find(params.expect(:id))
   end
 
   # Load project data for limited fields.
   def set_project_for_limited_fields
-    @project = Project.select(PROJECT_LIMITED_FIELDS).find(params[:id])
+    @project = Project.select(PROJECT_LIMITED_FIELDS).find(params.expect(:id))
   end
 
   # Optimized project loading for section-based actions - loads only needed fields.
@@ -1466,10 +1466,10 @@ class ProjectsController < ApplicationController
     # Load project with selected fields, or all fields if section unknown
     @project =
       if fields_to_load
-        Project.select(fields_to_load).find(params[:id])
+        Project.select(fields_to_load).find(params.expect(:id))
       else
         # Unknown section - load all fields as fallback
-        Project.find(params[:id])
+        Project.find(params.expect(:id))
       end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -202,7 +202,7 @@ class UsersController < ApplicationController
 
   # rubocop: disable Metrics/MethodLength, Metrics/AbcSize
   def show
-    @user = User.find(params[:id])
+    @user = User.find(params.expect(:id))
     respond_to :html, :json
     # Paginate the list of user-owned projects.
     # Use "select_needed" to minimize the fields we extract
@@ -241,7 +241,7 @@ class UsersController < ApplicationController
   # rubocop: enable Metrics/MethodLength, Metrics/AbcSize
 
   def edit
-    @user = User.find(params[:id])
+    @user = User.find(params.expect(:id))
     # Force redirect if current_user cannot edit.  Otherwise, the process
     # of displaying the edit fields (with their defaults) could cause an
     # unauthorized exposure of an email address.
@@ -310,7 +310,7 @@ class UsersController < ApplicationController
 
   # rubocop: disable Metrics/AbcSize, Metrics/MethodLength
   def update
-    @user = User.find(params[:id])
+    @user = User.find(params.expect(:id))
     old_email = @user&.email_if_decryptable
     user_parameter_values = compute_user_params
     @user.assign_attributes(user_parameter_values)
@@ -436,7 +436,7 @@ class UsersController < ApplicationController
 
   # Confirm that this user can edit; sets @user to the user to process
   def redir_unless_current_user_can_edit
-    @user = User.find(params[:id])
+    @user = User.find(params.expect(:id))
     return if current_user_can_edit?(@user)
 
     flash[:danger] = t('users.edit.inadequate_privileges')


### PR DESCRIPTION
PR #2985 (Dependabot) bumps rubocop-rails from 2.33.4 to 2.37.0 but fails CI: that version adds two new cops we'd never seen, Rails/Env (19 hits) and Rails/StrongParametersExpect (11 hits, in projects_controller.rb and users_controller.rb).

Fixed Rails/StrongParametersExpect for real rather than disabling it: params[:id] returns whatever the client sent, including an array (?id[]=1&id[]=2), and params.expect(:id) requires a scalar, raising a clean 400 instead. The clearest case was params[:ids].split(','): an array there would hit Array#split, an unhandled 500, not a rejection. SafeAutoCorrect is false for this cop (behavior changes on malformed input), so these 11 call sites were fixed by hand, not with `rubocop -a`.

Disabled Rails/Env instead of fixing it, the same way .rubocop.yml already disables Rails/EnvironmentComparison and others under the "not ready for it yet" block (issue #1069). Most hits are initializers and a rake task gating third-party setup by deployment environment (config/initializers/*, lib/tasks/default.rake); moving that into "config or a feature flag" would just relocate the same Rails.env coupling one file over. The app/models/user.rb cases the cop's testability rationale actually targets already solve that problem via an env_test: keyword letting tests exercise the production branch without touching RAILS_ENV - dependency injection, just not through Rails config.

Gemfile.lock updated via `bundle update rubocop-rails --conservative`; rubocop-rails 2.37.0 only needed rubocop >= 1.89.0, already met by our pinned 1.89.0, so nothing else moved.

Assisted-by: Claude:claude-sonnet-5

Claude-Session: https://claude.ai/code/session_0174ddfmVbMR5k752Kd2CdHS