### PR TITLE
Don't destroy a pending resubmission until it's actually accepted

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,11 +103,6 @@ class ApplicationController < ActionController::Base
   after_action :update_session_timestamp
   after_action :drop_unneeded_session_cookie
 
-  # Consumes a stashed pending resubmission the moment it's actually
-  # resubmitted, wherever that request lands (not just
-  # PendingResubmissionsController). See #finalize_pending_resubmission.
-  before_action :finalize_pending_resubmission
-
   # For the PaperTrail gem. We must call this *after* the action
   # `setup_authentication_state`; this action calls
   # our method `user_for_paper_trail` which reads from @session_user_id.
@@ -870,29 +865,46 @@ class ApplicationController < ActionController::Base
     pending.raw_token
   end
 
-  # Destroys a stashed pending resubmission once its resubmit form is
-  # actually submitted back, wherever that request lands (an ordinary
-  # controller action like ProjectsController#update, not
-  # PendingResubmissionsController's own #show, which reads only session
-  # and never this request's params). This is the ONLY place a row is
-  # destroyed in pending resubmissions in the normal application run; #show
-  # deliberately leaves it
-  # alone so revisiting the resume page after a closed tab or dropped
+  # Destroys a stashed pending resubmission once its resubmit form has
+  # actually been resubmitted AND the resulting change was accepted.
+  # Callers must call this only from a confirmed-successful save branch
+  # (ProjectsController#successful_update, UsersController#update's
+  # `if @user.save` branch), never as a blanket before_action keyed only on
+  # param presence. This is the ONLY place a row is destroyed in pending
+  # resubmissions in the normal application run; #show deliberately leaves
+  # it alone so revisiting the resume page after a closed tab or dropped
   # connection still works, and an abandoned stash is instead swept up
   # later by PendingResubmission.purge_stale.
   #
+  # This used to be a before_action, firing on any request carrying a
+  # pending_resubmission_token param regardless of outcome. That destroyed
+  # the stash the instant the *browser* GET'd the login page the initial
+  # redirect sent it to (login_path embeds the token in that URL so the
+  # view can thread it into the GitHub/local-login links), before the user
+  # had even logged in, let alone resubmitted anything (a real incident on
+  # staging, 2026-09-12). Worse, even confined to the real resubmit
+  # request, destroying it merely because a PATCH arrived (rather than
+  # because the PATCH's own save succeeded) would lose the draft for good
+  # on a validation failure or an ActiveRecord::StaleObjectError conflict,
+  # exactly what this whole feature exists to prevent. Gating on the HTTP
+  # response instead of the model's own save result isn't reliable either:
+  # ProjectsController#successful_update can *render* (not redirect) after
+  # a successful save (Save-and-Continue, Chief overrides), so "did this
+  # response redirect" doesn't mean "did this save succeed."
+  #
   # Reading the token from params here (rather than only from session, as
   # PendingResubmissionsController's own comment insists on for *display*)
-  # is safe: this only destroys a row, never shows its contents, and the
-  # token a request carries here is never one the requester merely
-  # guessed (it's 128 bits of SecureRandom that only ever reached a
-  # browser by that browser first passing the session-gated check in
-  # PendingResubmissionsController#show). Whoever can present it here could
-  # already have replayed the stash's own params directly.
+  # is safe from a malicious replay: this only destroys a row, never shows
+  # its contents, and the token a request carries here is never one the
+  # requester merely guessed (it's 128 bits of SecureRandom that only ever
+  # reached a browser by that browser first passing the session-gated
+  # check in PendingResubmissionsController#show). Whoever can present it
+  # here could already have replayed the stash's own params directly. That
+  # property was never the problem; premature destruction on an innocent,
+  # non-malicious request was.
   #
-  # A blank param is the overwhelmingly common case (an ordinary request
-  # never resubmits a stash), so this is a cheap early return on every
-  # other request in the app.
+  # A blank param is the overwhelmingly common case (an ordinary successful
+  # save never resubmits a stash), so this is a cheap early return.
   # @return [void]
   def finalize_pending_resubmission
     token = params[:pending_resubmission_token]

--- a/app/controllers/pending_resubmissions_controller.rb
+++ b/app/controllers/pending_resubmissions_controller.rb
@@ -28,8 +28,9 @@
 # "Resume" lost the stashed edit for good, with no way back. Revisiting
 # this page now just re-shows the same stash. A row is only ever consumed
 # by ApplicationController#finalize_pending_resubmission, once the browser
-# actually resubmits it (the hidden pending_resubmission_token field the
-# view below adds carries the token forward for that); an abandoned one is
+# actually resubmits it and that resubmission's save succeeds (the hidden
+# pending_resubmission_token field the view below adds carries the token
+# forward for that); an abandoned one is
 # swept up later by PendingResubmission.purge_stale (lib/tasks/default.rake's
 # `daily` task), so nothing lingers forever.
 class PendingResubmissionsController < ApplicationController

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1624,6 +1624,10 @@ class ProjectsController < ApplicationController
   # Handles successful project update responses and badge level changes.
   # Generates appropriate redirects, sends status change emails, and displays
   # congratulations or warning messages based on badge level changes.
+  # Only ever called from the `if @project.save` branch in #update, so this
+  # is also the one place that finalizes a pending resubmission: we know at
+  # this point the save actually succeeded, not just that a PATCH carrying
+  # a token arrived (see ApplicationController#finalize_pending_resubmission).
   # @param format [ActionController::MimeResponds::Collector] Response format
   # @param old_badge_level [String] Previous badge level before update
   # @param criteria_level [String] Current criteria level for navigation
@@ -1632,6 +1636,7 @@ class ProjectsController < ApplicationController
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   # TODO: Break this into smaller pieces
   def successful_update(format, old_badge_level, criteria_level)
+    finalize_pending_resubmission
     # Use Sections::DEFAULT_SECTION instead of hardcoded 'passing'
     section = criteria_level || Sections::DEFAULT_SECTION
     # @project.purge

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -318,6 +318,11 @@ class UsersController < ApplicationController
       @user.changes, old_email, @user.email_if_decryptable
     )
     if @user.save
+      # We know the save actually succeeded here, not just that a PATCH
+      # carrying a pending_resubmission_token arrived, so this is the right
+      # place to finalize one (see
+      # ApplicationController#finalize_pending_resubmission).
+      finalize_pending_resubmission
       # If user changed his own locale, switch to it.  It's possible for an
       # *admin* to change someone else's locale, in that case leave it alone.
       # Store preferred_locale once to avoid duplicate hash lookup

--- a/app/models/pending_resubmission.rb
+++ b/app/models/pending_resubmission.rb
@@ -73,7 +73,8 @@ class PendingResubmission < ApplicationRecord
   # PendingResubmissionsController#show renders lost the stash for good if
   # the browser never actually completed the resubmission, e.g. a closed
   # tab); ApplicationController#finalize_pending_resubmission only destroys
-  # a row once the browser actually resubmits it. Kept at the original 3
+  # a row once the browser actually resubmits it and that resubmission's
+  # save succeeds. Kept at the original 3
   # days (not shortened to 1, despite there no longer being an earlier
   # natural cleanup point) so a brief outage of the daily task itself, or
   # of the site, doesn't purge someone's still-unresumed edit out from

--- a/app/views/pending_resubmissions/show.html.erb
+++ b/app/views/pending_resubmissions/show.html.erb
@@ -5,7 +5,8 @@
 <%= form_with url: @resubmit_path, method: @resubmit_method do %>
   <%# Carries the stash's token forward so
       ApplicationController#finalize_pending_resubmission can consume it
-      once this actually gets resubmitted; see the class comment above. %>
+      once this actually gets resubmitted and the save succeeds; see the
+      class comment above. %>
   <%= hidden_field_tag :pending_resubmission_token, @pending_resubmission_token %>
   <% @fields.each do |name, value| %>
     <%= hidden_field_tag name, value %>

--- a/test/integration/pending_resubmission_test.rb
+++ b/test/integration/pending_resubmission_test.rb
@@ -15,6 +15,7 @@ require 'test_helper'
 # real browser's login-form hidden field or GitHub auth link would carry it,
 # rather than session; these tests thread it through that way instead of
 # reading it back from session mid-flow.
+# rubocop:disable Metrics/ClassLength
 class PendingResubmissionTest < ActionDispatch::IntegrationTest
   setup do
     @project = projects(:one)
@@ -136,6 +137,93 @@ class PendingResubmissionTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:github] = nil
   end
 
+  test 'merely viewing the login page the stash redirect sends you to does not destroy it' do
+    # Regression test for a real incident on staging (2026-09-12):
+    # ApplicationController#finalize_pending_resubmission used to be a
+    # before_action, firing on ANY request carrying a pending_resubmission_token
+    # param. redirect_to_login_stashing embeds that exact token in the
+    # /login URL it redirects to (so the login page's view can thread it
+    # into the GitHub/local-login links), so simply following that
+    # redirect (a GET, not a resubmission) destroyed the row before the
+    # user had even logged in, let alone resubmitted anything.
+    patch "/en/projects/#{@project.id}", params: { project: { name: 'never resubmitted yet' } }
+    token = pending_resubmission_token_from_redirect
+    assert_not_nil token
+
+    follow_redirect! # GET /en/login?pending_resubmission_token=...&return_to=...
+    assert_response :success
+    assert PendingResubmission.exists?(hashed_random_id: PendingResubmission.digest(token))
+
+    # The normal flow still works fine afterward: logging in still resumes it.
+    log_in_with_token(token)
+    assert_redirected_to pending_resubmission_path
+  end
+
+  test 'a successful resubmission destroys the stash' do
+    new_name = "#{@project.name}_resubmitted"
+    patch "/en/projects/#{@project.id}", params: { project: { name: new_name } }
+    token = pending_resubmission_token_from_redirect
+    log_in_with_token(token)
+    follow_redirect!
+
+    patch "/en/projects/#{@project.id}", params: {
+      project: { name: new_name }, pending_resubmission_token: token
+    }
+    @project.reload
+    assert_equal new_name, @project.name
+    assert_not PendingResubmission.exists?(hashed_random_id: PendingResubmission.digest(token))
+  end
+
+  test 'a resubmission that fails validation keeps the stash' do
+    # finalize_pending_resubmission must only fire once we KNOW the change
+    # was accepted (ProjectsController#successful_update only runs inside
+    # `if @project.save`), not merely because a PATCH carrying the token
+    # arrived: otherwise a validation failure on resubmission would lose
+    # the draft for good, exactly what this whole feature exists to
+    # prevent. TextValidator (app/validators/text_validator.rb) rejects
+    # control characters, giving a reliable, unconditional validation
+    # failure regardless of the project's other field values.
+    patch "/en/projects/#{@project.id}", params: { project: { name: 'will retry' } }
+    token = pending_resubmission_token_from_redirect
+    log_in_with_token(token)
+    follow_redirect!
+
+    patch "/en/projects/#{@project.id}", params: {
+      project: { name: "bad\x01name" }, pending_resubmission_token: token
+    }
+    assert_response :success # re-renders :edit; the save failed
+    assert PendingResubmission.exists?(hashed_random_id: PendingResubmission.digest(token))
+  end
+
+  test 'a successful user-profile resubmission destroys the stash too' do
+    # UsersController#update's `if @user.save` branch finalizes a pending
+    # resubmission the same way ProjectsController#successful_update does;
+    # this exercises that call site specifically; the tests above only
+    # cover the ProjectsController one. Reuses the 'foo@bar.com' email
+    # change and its matching VCR cassette from
+    # test/integration/users_edit_test.rb's "successful edit" test: any
+    # successful save by a local-provider user calls User#gravatar_exists?
+    # (an HTTP HEAD to Gravatar), whether or not this particular update
+    # actually changes the email, so the resubmit step needs a cassette
+    # recorded for whatever email ends up saved.
+    new_name = "#{@user.name}_resubmitted"
+    patch "/en/users/#{@user.id}", params: { user: { name: new_name } }
+    token = pending_resubmission_token_from_redirect
+    assert_not_nil token
+
+    log_in_with_token(token)
+    follow_redirect!
+
+    VCR.use_cassette('successful_edit_-_name_email') do
+      patch "/en/users/#{@user.id}", params: {
+        user: { name: new_name, email: 'foo@bar.com' }, pending_resubmission_token: token
+      }
+    end
+    @user.reload
+    assert_equal new_name, @user.name
+    assert_not PendingResubmission.exists?(hashed_random_id: PendingResubmission.digest(token))
+  end
+
   test 'a login without its own pending_resubmission_token never resumes a leftover one' do
     # Regression guard for the cross-user disclosure docs/login-session-18.md
     # "Step 21" closes: on a shared browser, an earlier abandoned stash must
@@ -174,3 +262,4 @@ class PendingResubmissionTest < ActionDispatch::IntegrationTest
     }
   end
 end
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
Found while debugging a failed staging deploy: ApplicationController #finalize_pending_resubmission was a global before_action, destroying a stashed resubmission the instant any request carried a pending_resubmission_token param. redirect_to_login_stashing embeds that exact token in the /login URL it redirects to, so simply following that redirect (a GET, to display the login page) destroyed the row before the user had even logged in, let alone resubmitted anything. Confirmed on staging via a one-off dyno: exactly one row was ever inserted and exactly one was ever deleted, both before the user's GitHub login completed.

Fixing only the GET case would still leave a subtler problem: the old design destroyed the stash the moment a matching PATCH arrived, not once its save actually succeeded. A resubmission that fails validation or hits an ActiveRecord::StaleObjectError conflict would lose the user's draft for good, exactly what this whole feature exists to prevent. Gating on the HTTP response instead isn't reliable either: ProjectsController#successful_update can render (not redirect) after a successful save (Save-and-Continue, Chief overrides), so "did this redirect" doesn't mean "did this save succeed."

Removed the before_action and call finalize_pending_resubmission explicitly instead, only from the two branches that know the save actually succeeded: ProjectsController#successful_update (only ever reached from `if @project.save`) and UsersController#update's `if @user.save` branch.

Added tests reproducing the exact staging failure (a GET to the login page must not destroy the stash), confirming a successful resubmission still destroys it (both controllers), and confirming a resubmission that fails validation keeps it.


Claude-Session: https://claude.ai/code/session_01JBEefuBjDNFXFLbCWZ7CMX